### PR TITLE
chore: add .claude config, docs, and ignore node/uv artifacts

### DIFF
--- a/.claude/commands/branch-analysis.md
+++ b/.claude/commands/branch-analysis.md
@@ -1,0 +1,121 @@
+# Branch Divergence Analysis
+
+You are performing a deep git branch divergence analysis for this repo. Follow each step precisely, then present the results in the structured format below.
+
+## Step 1: Ensure SSH credentials and fetch
+
+Run:
+
+```bash
+ssh-add -l 2>&1
+```
+
+- If `~/.ssh/id_ed25519_gh` is listed: proceed to fetch.
+- If it is NOT listed but the agent is running: tell the user to run `ssh-add ~/.ssh/id_ed25519_gh` (the GitHub key required for this repo) and then re-invoke the skill.
+- If the agent has no identities or is not running: list available keys with `ls ~/.ssh/*.pub 2>/dev/null`, identify the GitHub key (`id_ed25519_gh`), and ask the user to load it with `ssh-add <key>` before continuing.
+
+Then fetch:
+
+```bash
+git fetch --all 2>&1
+```
+
+If the fetch still fails with an authentication error, stop and ask the user to add the correct SSH key.
+
+Then run all of these in parallel:
+
+```bash
+git branch -a
+```
+```bash
+git log --oneline --all --graph
+```
+```bash
+git log --oneline origin/master..$(git branch --show-current) 2>/dev/null
+```
+
+Then, for each remote branch that is NOT `origin/master`, `origin/HEAD`, `origin/feature/unix`, `origin/feature/unix2`, `origin/logs` (already merged), compute:
+
+```bash
+git log --oneline origin/master..<branch>
+git diff origin/master...<branch> --stat
+git merge-tree --write-tree origin/master <branch> 2>&1
+```
+
+Run all branch checks in parallel.
+
+## Step 2: Assess local sync state
+
+Check whether local tracking branches (`master`, `main`, current branch) are behind `origin/master`:
+
+```bash
+git log --oneline master..origin/master 2>/dev/null | wc -l
+git log --oneline main..origin/master 2>/dev/null | wc -l
+```
+
+## Step 3: For every branch with unmerged commits
+
+- List all files it touches vs `origin/master` (`git diff origin/master...<branch> --name-only`)
+- Run `git merge-tree --write-tree origin/master <branch>` and capture any `CONFLICT` lines
+- For each conflicting file, show: the master version (`git show origin/master:<file>`) and the branch version (`git show <branch>:<file>`) side by side, summarising the semantic difference in one sentence
+
+## Step 4: Present the analysis
+
+Output the following sections **in this exact format**:
+
+---
+
+### Local sync state
+
+State whether local `master`/`main` are behind `origin/master` and by how many commits. Flag it clearly if they need a fast-forward pull before anything else.
+
+---
+
+### Branches already merged into origin/master
+
+List any branches whose commits are fully contained in `origin/master`. One line each: branch name + what it added.
+
+---
+
+### Branches still unmerged
+
+For each unmerged branch, a block:
+
+```
+#### <branch-name>
+Commits ahead: N
+Files touched: <list>
+Conflict risk: None | Low | High
+<If conflicts: describe each conflict file, what each side has, and the recommended resolution>
+<If no conflicts: "Clean merge — no conflicts expected.">
+```
+
+---
+
+### Merge plan
+
+Propose a merge order. For each step:
+- Branch name
+- Why it comes first (dependencies, conflict risk, size)
+- What to expect (auto-merge vs manual resolution required)
+- For manual resolutions: exact resolution instructions (which side to keep, what to reconcile)
+
+---
+
+### Shell script offer
+
+After the full analysis, ask the user:
+
+> Would you like me to write a shell script that performs these merges in the proposed order, pausing at conflicts with instructions?
+
+**Never write the script or run any merge commands unless the user explicitly confirms.**
+
+If the user says yes, write a shell script (do not run it) that:
+- Sets `set -e` and prints each step before executing
+- Does `git fetch --all` first
+- Fast-forwards local tracking branches if needed
+- Merges each branch in the proposed order
+- For branches with known conflicts: after the merge attempt, prints clear instructions for each conflict file (what to keep, what to discard) and exits with a non-zero code so the user can resolve manually before re-running
+- At the end, optionally pushes to origin (gated behind a `--push` flag)
+
+Save the script to `scripts/merge-branches.sh` (do not execute it). Tell the user to review it before running.

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "WebFetch(domain:github.com)",
+      "WebSearch"
+    ]
+  }
+}

--- a/.claude/skills/captains-log/SKILL.md
+++ b/.claude/skills/captains-log/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: captains-log
+description: Aggregate today's git activity from your work repo and write a structured journal entry to the Obsidian vault's 06-daily/ folder.
+user-invocable: true
+---
+
+# Skill: Captain's Log
+
+Pulls recent git commits from your configured repos and writes a structured daily journal entry to the vault. Creates a searchable record of what shipped and why.
+
+> Locations come from `~/.config/danfault/vault.yaml`: `<vault>` = `danfault vault path`, repos = `danfault vault repos` (add `--github` for slugs).
+
+## Usage
+```
+/captains-log
+```
+
+## Instructions
+
+1. **Get today's date:**
+   ```bash
+   date +%Y-%m-%d
+   ```
+
+2. **Pull recent git activity from your configured repos** — iterate over every repo in `~/.config/danfault/vault.yaml`:
+   ```bash
+   for repo in $(danfault vault repos); do
+     echo "## $repo"
+     git -C "$repo" log --oneline --since="24 hours ago" --author="$(git config user.email)" 2>/dev/null
+   done
+   ```
+   Also check for any open PRs across those repos:
+   ```bash
+   for slug in $(danfault vault repos --github); do
+     gh pr list --repo "$slug" --author "@me" --state open --json number,title,url 2>/dev/null
+   done
+   ```
+
+3. **Check today's daily note** — see if one already exists at `<vault>/06-daily/<date>.md`. If it does, append to it; if not, create it.
+
+4. **Write the journal entry** using the Write or Edit tool at `<vault>/06-daily/<date>.md`:
+
+   ```markdown
+   ---
+   title: <date>
+   type: daily
+   domain: work
+   tags: ["daily", "captains-log"]
+   status: active
+   ---
+
+   ## Captain's Log — <date>
+
+   ### Shipped
+   <list of commits, one per line with description>
+
+   ### Open PRs
+   <list of open PRs with links>
+
+   ### Notes
+   <ask the user if they want to add any notes or reflections>
+   ```
+
+5. **Ask** if the user wants to add notes or reflections before saving.
+
+6. **Reindex** — run incremental reindex so the entry is immediately searchable:
+   ```bash
+   VAULT_PATH="$(danfault vault path)" \
+   DB_PATH=~/danfault/python/obsidian-mcp/data/vectors.db \
+   uv run --project ~/danfault/python/obsidian-mcp obsidian-index
+   ```
+
+7. **Confirm** — tell the user the note path.

--- a/.claude/skills/capture/SKILL.md
+++ b/.claude/skills/capture/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: capture
+description: Capture an insight or note into the Obsidian vault's 00-inbox/ with proper frontmatter, then trigger an incremental reindex so it's immediately searchable.
+user-invocable: true
+---
+
+# Skill: Capture Note to Vault
+
+Use when the user wants to save an insight, reference, or note from the current session into the Obsidian vault.
+
+## Usage
+```
+/capture
+/capture "Some insight about X"
+```
+
+## Instructions
+
+1. **Get the content** — if the user passed text after `/capture`, use that. Otherwise ask: "What would you like to capture?"
+
+   If the content is vague or the user says "from the session" or "from recent work", you may read existing reports in the relevant project's `reports/` folder to gather context:
+   ```bash
+   ls "$(danfault vault path)"/01-projects/<project>/reports/ 2>/dev/null
+   ```
+   Read the relevant report files to extract the insight. **Never modify, overwrite, or delete any report file — reports are read-only sources for capture.**
+
+2. **Get metadata** — ask for (or infer from context):
+   - `title` — short descriptive title that becomes the filename slug. File will be saved as `YYYY-MM-DD-<slug>.md`. **Good titles are specific and scannable:** `pit-join-vs-exact-join`, `strict-less-than-semantics`, `stddev-nan-on-single-value-window`. Avoid vague titles like `session-notes`, `insight`, `fix`.
+   - `domain` — the note's domain. List the vault's declared domains with `danfault vault domains` and pick the best match; if none fit, ask the user. Each vault declares its own set (in `~/.config/danfault/vault.yaml`), so a work vault and a personal vault can offer different domains.
+   - `tags` — 1–3 relevant tags (infer if obvious)
+
+3. **Run the capture tool:**
+   ```bash
+   VAULT_PATH="$(danfault vault path)" \
+   DB_PATH=~/danfault/python/obsidian-mcp/data/vectors.db \
+   uv run --project ~/danfault/python/obsidian-mcp \
+     obsidian-capture "<content>" \
+     --title "<title>" \
+     --domain "<domain>" \
+     --tags <tag1> <tag2>
+   ```
+
+4. **Confirm** — tell the user the note path and that it's now searchable via `obsidian_search`.

--- a/.claude/skills/mermaid-extract/SKILL.md
+++ b/.claude/skills/mermaid-extract/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: mermaid-extract
+description: Extract mermaid diagrams from a markdown file and optionally render them in the browser via localhost
+user-invocable: true
+---
+
+# Skill: mermaid-extract
+
+Extract all ` ```mermaid ` blocks from a markdown file. Diagrams are saved as `.mmd` files in `~/.cache/mermaid-extract/<filename>/`. With `--server`, an HTML page using mermaid.js is served at localhost and opened in the browser.
+
+## Usage
+```
+/mermaid-extract <path/to/file.md>
+/mermaid-extract <path/to/file.md> --server
+/mermaid-extract <path/to/file.md> --server --port 9000
+```
+
+## Instructions
+
+1. Identify the markdown file path from the user's argument. If not provided, ask for it.
+2. Run the CLI:
+   - Without browser preview: `mermaid-extract <path>`
+   - With browser preview: `mermaid-extract <path> --server`
+   - Custom port: add `--port <number>`
+3. Report back:
+   - How many diagrams were found
+   - Where the `.mmd` files were saved (`~/.cache/mermaid-extract/<stem>/`)
+   - The localhost URL if `--server` was used
+4. If no diagrams were found, tell the user and suggest checking the file for ` ```mermaid ` blocks.

--- a/.claude/skills/obsidian-index/SKILL.md
+++ b/.claude/skills/obsidian-index/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: obsidian-index
+description: Run an incremental reindex of the Obsidian vault so new or changed notes become searchable via obsidian_search.
+user-invocable: true
+---
+
+# Skill: Reindex Obsidian Vault
+
+Use when notes have been added or edited and you want them immediately available to `obsidian_search`.
+
+## Usage
+```
+/obsidian-index
+/obsidian-index --full
+```
+
+## Instructions
+
+1. **Check for `--full` flag** — if present, do a full reindex (clears and rebuilds). Otherwise do incremental (only changed files).
+
+2. **Run the indexer:**
+
+   Incremental:
+   ```bash
+   VAULT_PATH="$(danfault vault path)" \
+   DB_PATH=~/danfault/python/obsidian-mcp/data/vectors.db \
+   uv run --project ~/danfault/python/obsidian-mcp obsidian-index
+   ```
+
+   Full:
+   ```bash
+   VAULT_PATH="$(danfault vault path)" \
+   DB_PATH=~/danfault/python/obsidian-mcp/data/vectors.db \
+   uv run --project ~/danfault/python/obsidian-mcp obsidian-index --full
+   ```
+
+3. **Report** — show the output (chunks indexed, files unchanged).

--- a/.claude/skills/project-init/SKILL.md
+++ b/.claude/skills/project-init/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: project-init
+description: Initialize a new project in the Obsidian vault's 01-projects/ folder with a standard structure (SUMMARY.md, learnings/, documents/, reports/).
+user-invocable: true
+---
+
+# Skill: Initialize Project in Vault
+
+Use when starting a new project that warrants tracking in the vault.
+
+> `<vault>` below resolves via `danfault vault path` (from `~/.config/danfault/vault.yaml`).
+
+## Usage
+```
+/project-init
+/project-init "my-project"
+```
+
+## Instructions
+
+1. **Get the project name** — if passed as argument, use it. Otherwise ask:
+   "What's the project name? (will become the folder name, e.g. `my-project`)"
+
+2. **Get metadata** — ask for:
+   - `title` — human-readable title (e.g. "My Project")
+   - `domain` — one of the vault's declared domains. List them with `danfault vault domains`; if none fit, ask the user.
+   - `goal` — one sentence: what is this project trying to achieve?
+   - `status` — `active` or `draft`
+
+3. **Create the folder structure** using the Write tool:
+
+   ```
+   <vault>/01-projects/<project-name>/
+     SUMMARY.md
+     learnings/      (empty, create a .gitkeep)
+     documents/      (empty, create a .gitkeep)
+     reports/        (empty, create a .gitkeep)
+   ```
+
+4. **Write `SUMMARY.md`** with this template:
+
+   ```markdown
+   ---
+   title: <title>
+   type: project
+   domain: <domain>
+   tags: []
+   status: <status>
+   created: <today>
+   ---
+
+   # <title>
+
+   **Goal:** <goal>
+
+   ## Current Status
+
+   > Update this section each session.
+
+   ## Folder Structure
+
+   | Folder | Purpose |
+   |--------|---------|
+   | `learnings/` | Reusable platform knowledge discovered during this project |
+   | `documents/` | Reference docs, PRDs, external material |
+   | `reports/` | Session outputs, validation results, analysis |
+
+   ## Key Links
+
+   _(add links to PRs, Databricks notebooks, Confluence pages here)_
+
+   ## Notes for Next Session
+
+   _(update before closing each session)_
+   ```
+
+5. **Trigger reindex:**
+   ```bash
+   VAULT_PATH="$(danfault vault path)" \
+   DB_PATH=~/danfault/python/obsidian-mcp/data/vectors.db \
+   uv run --project ~/danfault/python/obsidian-mcp obsidian-index
+   ```
+
+6. **Confirm** — tell the user the path and suggest: "Use `/vault-review` at the end of each session to capture learnings here."

--- a/.claude/skills/vault-help/SKILL.md
+++ b/.claude/skills/vault-help/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: vault-help
+description: Display all available commands and tools for interacting with the Obsidian vault.
+user-invocable: true
+---
+
+# Skill: Vault Help
+
+Show all available vault commands.
+
+## Usage
+```
+/vault-help
+```
+
+## Instructions
+
+Display the following reference exactly as formatted:
+
+---
+
+## Vault Commands
+
+### Configuration
+
+Locations and domains are read from a machine-local config (never committed):
+`~/.config/danfault/vault.yaml`. Resolve values with the `danfault vault` CLI:
+
+| Command | Returns |
+|---|---|
+| `danfault vault path [--vault NAME]` | Absolute path to a vault (default: `default_vault`) |
+| `danfault vault domains [--vault NAME]` | The vault's declared note domains, one per line |
+| `danfault vault repos [--github]` | Every configured repo's path (or `owner/repo` slug) |
+| `danfault vault repo NAME [--github]` | One repo's path (or its `owner/repo` slug) |
+
+Skills use these instead of hardcoding paths, so the same skill works on any
+machine and across separate work/personal vaults.
+
+### Skills
+
+| Command | When to use |
+|---|---|
+| `/capture` | Save a quick insight or note to `00-inbox/` with frontmatter |
+| `/captains-log` | Pull today's work-repo git activity → write a journal entry to `06-daily/` |
+| `/obsidian-index` | Manually reindex the vault (use after editing notes outside Claude) |
+| `/obsidian-index --full` | Full reindex — clears and rebuilds the entire index |
+| `/vault-session-review` | Review session: suggest captures, report, and **update `status.md`** |
+| `/vault-report` | Write a dated session report to a project's `reports/` folder |
+| `/project-init` | Scaffold a new project in `01-projects/` with SUMMARY.md + folders |
+| `/vault-help` | Show this reference |
+
+### MCP Tools (available in any Claude session)
+
+| Tool | What it does |
+|---|---|
+| `obsidian_search` | Hybrid BM25 + semantic search across the vault |
+| `obsidian_read_note` | Read a full note by vault-relative path |
+| `obsidian_list_notes` | List notes filtered by folder or tag |
+| `obsidian_get_context` | Get a compact context block for a topic (for prompt injection) |
+
+### Automatic Behaviors (hooks)
+
+| Trigger | What happens |
+|---|---|
+| Claude writes/edits a file in `<vault>/` | Vault is automatically reindexed in the background |
+
+### Vault Structure
+
+```
+vault/
+├── 00-inbox/       New notes land here (via /capture or manual triage)
+├── 01-projects/    Active and past projects (SUMMARY + status + learnings + reports)
+├── 02-areas/       Ongoing responsibilities (policies, troubleshooting, tool ideas)
+├── 03-resources/   Reference material (tools, frameworks, setup notes)
+├── 04-archive/     Completed projects, old meetings, feedback
+├── 06-daily/       Daily notes (2025+, date-named)
+├── 07-templates/   Note templates (excluded from index)
+└── .indexignore    Exclusion rules for AI indexing
+```
+
+### What's excluded from the index
+
+- `07-templates/` — placeholder variables degrade retrieval
+- `08-attachments/` — binary files
+- `06-daily/` — low-signal logs (remove from .indexignore if daily notes become substantive)
+- `04-archive/feedbacks/` — sensitive peer review content
+- `01-projects/**/reports/` — operational snapshots (S3 paths, execution IDs, commits)
+
+### Project structure (inside `01-projects/<name>/`)
+
+| File/Folder | Purpose | Indexed? |
+|---|---|---|
+| `SUMMARY.md` | Stable overview, goal, key links | ✅ |
+| `status.md` | Live status — overwrite each session | ✅ |
+| `learnings/` | Durable platform knowledge | ✅ |
+| `documents/` | Reference docs, PRDs | ✅ |
+| `reports/` | Operational session snapshots | ❌ |

--- a/.claude/skills/vault-report/SKILL.md
+++ b/.claude/skills/vault-report/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: vault-report
+description: Write a dated session report to a project's reports/ folder in the Obsidian vault. Confirms the project and summarizes content before writing.
+user-invocable: true
+---
+
+# Skill: Vault Report
+
+Write a session report to `01-projects/<name>/reports/` in the vault.
+
+> `<vault>` resolves via `danfault vault path`; `<work-repo>` in the examples is any repo from `danfault vault repos` (all from `~/.config/danfault/vault.yaml`).
+
+## Usage
+```
+/vault-report
+/vault-report my-project
+```
+
+## Instructions
+
+1. **Identify the project** — if a project name was passed as argument, use it. Otherwise list available projects and ask:
+   ```bash
+   ls "$(danfault vault path)"/01-projects/
+   ```
+   Ask: "Which project is this report for?"
+
+2. **Confirm the project exists:**
+   ```bash
+   ls "$(danfault vault path)"/01-projects/<project-name>/reports/ 2>/dev/null || echo "not found"
+   ```
+   If not found, ask the user to confirm the exact project name.
+
+3. **Gather report content** — scan the current session for operational output worth recording.
+
+   **Always collect:**
+
+   - **Working directories** — every directory that was the focus of work during the session (not just tool calls, but where the work actually happened). Examples: `<work-repo>`, `<vault>`, `~/danfault`. List each one.
+
+   - **Branches touched** — for each working directory that is a git repo, check the active branch and recent commits:
+     ```bash
+     git -C <dir> branch --show-current 2>/dev/null
+     git -C <dir> log --oneline --since="12 hours ago" --author="$(git config user.email)" 2>/dev/null
+     ```
+
+   - **Files touched** — significant files read, created, or edited during the session (grouped by directory if multiple repos were involved).
+
+   **Include if present:**
+   - Commits and what they changed
+   - Execution IDs, run IDs, job IDs (adhoc, Databricks, CI, batch jobs)
+   - Output locations (S3 paths, notebook paths, table names, file paths)
+   - Results or outcomes (validation, test results, metrics, build output, errors)
+   - Decisions too specific or volatile to go in `learnings/`
+   - Open issues or blockers discovered
+
+   Skip any category with no content for this session.
+
+4. **Determine a short topic slug** from the session's main activity (e.g. `null-fix`, `initial-setup`, `ci-debug`, `smoke-tests`).
+
+5. **Check for existing reports today:**
+   ```bash
+   ls "$(danfault vault path)"/01-projects/<project-name>/reports/$(date +%Y-%m-%d)*.md 2>/dev/null
+   ```
+   If one or more files already exist for today, show them to the user:
+   ```
+   Reports already exist for today:
+     - 2026-05-18-smoke-tests.md
+   ```
+   Then continue normally — the slug will naturally differentiate the new file. If the proposed slug would produce a filename that already exists, append `-2`, `-3`, etc. until the name is unique. Never overwrite an existing report.
+
+6. **Present a summary for confirmation** before writing anything:
+   ```
+   Project:  <project-name>
+   File:     01-projects/<project-name>/reports/<YYYY-MM-DD>-<slug>.md
+
+   Will include:
+   - Working dirs: <work-repo>, <vault>
+   - Branches: you/feature-branch (<work-repo>)
+   - Files touched: SomeModule.scala, status.md (vault)
+   - Commits: abc1234, def5678
+   - Results: re-run pending, NaN guard confirmed
+
+   Proceed?
+   ```
+
+   Wait for the user to confirm (or adjust) before writing.
+
+7. **Write the report** with a structure that fits the content. Use H2 sections. Only include sections with content:
+
+   ```markdown
+   # Session Report — <YYYY-MM-DD> — <topic>
+
+   ## Working directories
+
+   - `<work-repo>` — branch: `you/feature-branch`
+   - `<vault>` — vault updates
+
+   ## Files touched
+
+   - `path/to/file` — <what changed>
+
+   ## Commits
+
+   | Commit | Description |
+   |---|---|
+   | `<hash>` | <what it fixed> |
+
+   ## <Other categories as needed>
+
+   ## Notes
+   <open questions, blockers, next steps>
+   ```
+
+   The structure is flexible — match it to what actually happened.
+
+8. **Confirm** after writing — show the file path. Do NOT trigger a reindex (reports are excluded from the index by design).

--- a/.claude/skills/vault-session-review/SKILL.md
+++ b/.claude/skills/vault-session-review/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: vault-session-review
+description: Review the current session and suggest what's worth capturing to the Obsidian vault. Covers learnings, decisions, debugging patterns, platform insights, operational output, and project status updates.
+user-invocable: true
+---
+
+# Skill: Vault Review
+
+Use at the end of a session to identify content worth preserving in the vault.
+
+## Usage
+```
+/vault-session-review
+```
+
+## Instructions
+
+1. **Review the session** across three dimensions:
+
+   **A — Durable knowledge** (goes to `learnings/`, `03-resources/`, or `00-inbox/` via `/capture`):
+   - Learnings: how something works, a platform behavior, a framework detail
+   - Decisions: architectural or design choices made with rationale
+   - Debugging patterns: root causes found, investigation steps that worked
+   - Reference material: commands, configs, or workflows that would be useful again
+
+   **B — Operational output** (goes to `reports/` via `/vault-report`):
+   - Commits made and what they fixed
+   - Execution IDs, run IDs, adhoc job IDs
+   - Output locations (S3 paths, notebook paths, table names)
+   - Validation or test results
+   - Branches touched across repos
+   - Significant files created or modified
+
+   **C — Project status** (overwrites `01-projects/<name>/status.md`):
+   - What was completed this session (per-op validation results, fixes applied)
+   - What is blocked and why
+   - What comes next (concrete next steps for the next session)
+   - Active clusters, branches, PR numbers
+
+2. **Filter ruthlessly for durable knowledge** — skip:
+   - Anything too session-specific to generalize
+   - Content already well-documented in the codebase or vault
+   - Ephemeral output that belongs in a report, not a learning
+
+3. **Present three sections** — only show a section if there's content for it:
+
+   ```
+   Worth capturing (durable):
+   1. [Learning] "date.cast('long') gives days, not epoch seconds" → 03-resources/
+   2. [Decision] "feature X uses PIT join, not exact join" → 01-projects/.../learnings/
+
+   Worth reporting (operational):
+   - Commits: abc1234 (null fix), def5678 (NaN guard)
+   - Adhoc: execution <run-id>, S3 paths for the outputs
+   - Branches: you/feature-branch (<work-repo>)
+   → Suggest: /vault-report my-project
+
+   Project status update (01-projects/my-project/status.md):
+   - Feature A: ✅ DONE (PR #12345)
+   - Feature B: ⏳ divergence unresolved
+   - Next: investigate the discrepancy in the upstream source
+   ```
+
+   If the session touches a project tracked in `01-projects/`, **always** include the status section — even if no durable knowledge or operational output was produced.
+
+4. **Handle each section:**
+
+   For **durable captures** — ask "Want to capture this?" for each item and run `/capture`:
+   ```bash
+   VAULT_PATH="$(danfault vault path)" \
+   DB_PATH=~/danfault/python/obsidian-mcp/data/vectors.db \
+   uv run --project ~/danfault/python/obsidian-mcp \
+     obsidian-capture "<content>" --title "<title>" --domain "<domain>" --tags <tags>
+   ```
+   Or write directly to the appropriate project folder if it already exists in the vault.
+
+   For **operational output** — ask "Want to write a session report?" and if yes, invoke `/vault-report` with the project name pre-filled.
+
+   For **project status** — ask "Want to update status.md?" and if yes, **overwrite** (do not append) `01-projects/<project>/status.md` with the new state. The file must always reflect current reality, not accumulated history. Keep the same structure as the existing file: per-op validation table, detail sections for blocked items, recent commits, next session steps, and persistent operational notes (clusters, permissions). Update the `Last updated:` line to today's date.

--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,9 @@ dmypy.json
 # Pyre type checker
 .pyre/
 .idea
+
+# Node
+node_modules/
+
+# Generated / sensitive local data (holds plaintext Obsidian note chunks)
+python/obsidian-mcp/data/

--- a/docs/branch-status.md
+++ b/docs/branch-status.md
@@ -1,0 +1,44 @@
+# Branch Status
+
+> Last updated: 2026-07-01
+
+## Uncommitted work being organized (stacked off `feature/upgrades_macos`)
+
+A large batch of new tools was sitting uncommitted in the working tree. It is being
+split into stacked feature branches (each builds on the previous so the `.gitignore`
+rules apply throughout). Merge into `master` in order.
+
+| Order | Branch | Contents |
+|-------|--------|----------|
+| 1 | `chore/repo-meta` | `.gitignore` (ignore `node_modules/`, `obsidian-mcp/data/`), `.claude/` config + skills, docs |
+| 2 | `feature/danfault-cli-tools` | `arc` (folder→markdown) + `spotify` CLI, `spoti-ui/` dashboard, docs, `examples/spotify/` |
+| 3 | `feature/shell-helpers` | `dotfiles/.methods` — `find-folder`, `find-file` |
+| 4 | `feature/terminal-configs` | `terminal-configs/` backup/restore scripts |
+| 5 | `feature/mermaid-extract` | `python/mermaid-extract/` typer CLI package |
+| 6 | `feature/obsidian-mcp` | `python/obsidian-mcp/` vault search server (index data is gitignored) |
+
+### Notes
+- `spoti-ui/node_modules/` and `obsidian-mcp/data/` are gitignored (72 MB deps / 7 MB
+  index of plaintext note chunks — regenerable, not committed).
+- `main.py` imports both `arc` and `spotify`, so those two land together (branch 2).
+
+---
+
+## Pre-existing branches (from 2026-04-26 review)
+
+| Branch | Commits ahead of master | What it contains | Notes |
+|--------|------------------------|-----------------|-------|
+| `feature/upgrades_macos` | 3 | dotfiles, python/danfault, latex, setup | Base for the stack above; merge first |
+| `origin/patch/change_in_utils` | 1 | Small util additions | Quick patch |
+| `origin/fearture/module_manager` | 3 | Module validator/manager feature | Check if complete |
+| `origin/feature/job` | 3 | Git configs + job-related setup | Review before merging |
+
+### Fully merged — safe to delete
+`origin/feature/unix`, `origin/feature/unix2`, `origin/logs`
+
+---
+
+## `main` vs `master`
+`main` and `master` diverged (1 commit each). `main`'s unique commit (`Includes new
+features`) is already in `feature/upgrades_macos`, so `main` can be deleted once the
+stack is merged.

--- a/docs/coffee.md
+++ b/docs/coffee.md
@@ -1,0 +1,59 @@
+# Coffee Calculator
+
+A desktop GUI tool for calculating coffee-to-water proportions.
+
+## Install
+
+```bash
+cd python/danfault
+pip install -e ".[gui]"
+```
+
+Requires Python 3.8+ and PyQt6 (installed via the `gui` extra above).
+
+## Run
+
+```bash
+coffee
+```
+
+## Usage
+
+Fill in any two of the three fields — results appear inline as you type.
+
+| Ratio | Coffee (g) | Water (g) | Shows |
+|-------|-----------|-----------|-------|
+| ✅ | ✅ | — | Water needed (gray) |
+| ✅ | — | ✅ | Coffee needed (gray) |
+| — | ✅ | ✅ | Derived ratio (gray) |
+| ✅ | ✅ | ✅ consistent | ✓ (green) next to ratio |
+| ✅ | ✅ | ✅ inconsistent | ✗ (red) + targets and diffs per field |
+
+**Diff colors:** `(+Xg)` in green means you need to add more; `(-Xg)` in red means you have too much.
+
+### Ratio format
+
+The ratio field accepts `coffee:water` in any scale:
+
+```
+1:15      → 1g coffee per 15g water
+15:200    → 15g coffee per 200g water (same as 1:13.33)
+```
+
+## Recipes
+
+Built-in presets:
+
+| Recipe | Ratio |
+|--------|-------|
+| V60 | 1:15 |
+| French Press | 1:10 |
+| Espresso | 1:2 |
+| Chemex | 1:17 |
+| AeroPress | 1:13 |
+| Cold Brew | 1:5 |
+| Moka Pot | 1:7 |
+
+**Apply** — loads the selected recipe's ratio into the ratio field.
+
+**Save as…** — saves the current ratio field as a named recipe. Custom recipes are persisted at `~/.config/danfault/coffee_recipes.json` and merged with the built-in list on startup.


### PR DESCRIPTION
## Summary

Tightens `.gitignore` so generated Node/data artifacts can never be committed, and adds the local Claude Code configuration (skills + a branch-analysis command) plus two docs.

## What changed

- **`.gitignore`** — ignore `node_modules/` (Node deps) and `python/obsidian-mcp/data/` (a regenerable vector index that holds **plaintext chunks of a private Obsidian vault** — must never be committed).
- **`.claude/`** — `settings.local.json`, `commands/branch-analysis.md`, and 8 vault-oriented skills (`capture`, `captains-log`, `project-init`, `obsidian-index`, `mermaid-extract`, `vault-help`, `vault-report`, `vault-session-review`).
- **`docs/branch-status.md`** — refreshed branch/merge overview.
- **`docs/coffee.md`** — documents the existing `coffee` tool.

## Notes
- `.claude/settings.local.json` is committed intentionally despite the usual "keep it local" convention (it only contains a small permissions allowlist).