### PR TITLE
feat(danfault): add arc folder-to-markdown and spotify CLI + UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,16 @@ Personal dotfiles and tools.
 ## Tools
 
 - **[coffee](docs/coffee.md)** — GUI calculator for coffee-to-water proportions, with recipe presets.
+- **[spoti](docs/spoti.md)** — Spotify CLI and playlist analysis dashboard (Web API, OAuth PKCE).
 
+## Install (Python tools)
 
+```bash
+cd python/danfault
+pip install -e .
+```
 
-# Cedilla problem
-[This](https://www.danielkossmann.com/pt/ajeitando-cedilha-errado-ubuntu-linux/) fixed the problem for me in Ubuntu 
+Registers: `danfault`, `spoti`, `coffee`, `rmatlab`.
+
+## Cedilla problem
+[This](https://www.danielkossmann.com/pt/ajeitando-cedilha-errado-ubuntu-linux/) fixed the problem for me in Ubuntu.

--- a/docs/spoti.md
+++ b/docs/spoti.md
@@ -1,0 +1,338 @@
+# spoti — Spotify from the command line
+
+A CLI that controls Spotify through the **Spotify Web API**. Because it talks to
+Spotify's servers (not a local app), it can drive *any* of your devices — laptop,
+phone, or speakers.
+
+## Why the Web API (and not `dbus-send`)?
+
+| Approach | Linux | macOS | Reach |
+|----------|:-----:|:-----:|-------|
+| `dbus-send` / `playerctl` | ✅ | ❌ | Local app only (MPRIS over D-Bus, Linux-only) |
+| AppleScript (`osascript`) | ❌ | ✅ | Local Mac app only |
+| **Web API (this tool)** | ✅ | ✅ | **Any device on your account** |
+
+D-Bus does not exist on macOS, and AppleScript can only reach the Spotify app
+running on the same Mac. The Web API works everywhere and can control playback on
+your phone or a speaker from your terminal.
+
+## Install
+
+```bash
+cd python/danfault
+pip install -e .
+```
+
+This registers the standalone `spoti` command. The same commands are also
+available under `danfault spotify ...`.
+
+## One-time setup: get a Client ID
+
+The Web API requires you to register a (free) app to get a **Client ID**. This
+takes about two minutes.
+
+1. Go to <https://developer.spotify.com/dashboard> and log in with your normal
+   Spotify account.
+2. Click **Create app**.
+3. Fill in any **name** and **description** (e.g. `spoti-cli`).
+4. **Redirect URI** — type exactly:
+
+   ```
+   http://127.0.0.1:8888/callback
+   ```
+
+   It must match character-for-character (use `127.0.0.1`, *not* `localhost`).
+5. Under **APIs to use**, check **Web API**.
+6. Save, open the app, and copy the **Client ID**.
+
+Then log in once:
+
+```bash
+spoti login --client-id <your-client-id>
+```
+
+The Client ID is saved, so future logins are just `spoti login`. You can also
+provide it via the `SPOTIFY_CLIENT_ID` environment variable instead.
+
+> The Client ID is **not** a secret — it's safe to keep in config. Thanks to
+> PKCE (below) there is no client *secret* involved at all.
+
+## How login works
+
+`spoti login` uses OAuth 2.0 **Authorization Code with PKCE**. In plain terms:
+
+1. The CLI generates a one-time random secret (the *code verifier*) and a hashed
+   version of it (the *code challenge*).
+2. Your **browser opens** to Spotify's "Allow access?" page, carrying the
+   challenge.
+3. You click **Accept**.
+4. Spotify redirects your browser to `http://127.0.0.1:8888/callback?code=…`.
+   The CLI is running a **tiny local web server** on that port that catches the
+   redirect — so there's nothing to copy-paste.
+5. The CLI sends the code **plus the original verifier** to Spotify, which proves
+   the request came from the same program that started it, and gets back your
+   tokens.
+6. The browser shows a "✓ Authorized — you can close this tab" page, and the
+   local server shuts down.
+
+PKCE is what lets a CLI authenticate **without a client secret**: the verifier
+takes its place and is generated fresh each time, never stored long-term.
+
+## Token storage & security
+
+After login, Spotify issues two tokens, cached in:
+
+```
+~/.config/danfault/spotify.json
+```
+
+| Token | Lifetime | Purpose |
+|-------|----------|---------|
+| **access token** | ~1 hour | Sent with every API call to authorize it |
+| **refresh token** | long-lived | Used to silently mint a new access token when it expires |
+
+What keeps this safe:
+
+- **The file is in your home folder, never in the repo or git.**
+- **It's locked to `chmod 600`** (owner read/write only) because the refresh
+  token is a real credential — anyone who has it could control your Spotify.
+- **No client secret exists** to leak (that's the point of PKCE).
+- **Scopes are minimal.** The tool requests only what it needs:
+  - Playback: `user-read-playback-state`, `user-modify-playback-state`, `user-read-currently-playing`
+  - Playlists (read-only): `playlist-read-private`, `playlist-read-collaborative`
+  The token cannot read your email, modify your library, or write anything.
+- **Refresh is automatic.** When the 1-hour access token expires, the CLI uses
+  the refresh token to get a new one — you won't be asked to log in again.
+
+To revoke locally, run `spoti logout` (deletes the file). To fully revoke
+access, remove the app under your Spotify account's *Apps* settings.
+
+> **Re-login after scope changes.** If you first logged in before the playlist
+> scopes were added, run `spoti login` once more to pick them up.
+
+## Command reference
+
+| Command | What it does |
+|---------|--------------|
+| `spoti login [--client-id <id>]` | Authorize via the browser; cache tokens |
+| `spoti logout` | Delete the cached tokens |
+| `spoti now` | Show the currently playing track + state + device |
+| `spoti play` | Resume playback |
+| `spoti play "<song>"` | Search for a song and pick one to play (arrow-key menu) |
+| `spoti play "<song>" --first/-f` | Play the top result, skipping the picker |
+| `spoti pause` | Pause playback |
+| `spoti playpause` (alias `spoti pp`) | Toggle based on current state |
+| `spoti next` | Skip to next track |
+| `spoti prev` | Go to previous track |
+| `spoti vol <0-100> [--yes/-y]` | Set volume (asks to confirm a jump up of +50 or more; `-y` skips the prompt) |
+| `spoti shuffle <on\|off>` | Toggle shuffle |
+| `spoti repeat <track\|context\|off>` | Set repeat mode |
+| `spoti devices` | List your devices (● = active) |
+| `spoti transfer "<name>"` | Move playback to a device (name is fuzzy-matched) |
+| `spoti search "<query>" [--play] [--type track]` | List results; `--play` opens the picker to play one |
+| `spoti playlist-export "<query>"` | Export a playlist to JSON for analysis |
+| `spoti enrich-bpm <file.json>` | Patch exported JSON with BPM from GetSongBPM |
+| `spoti ui [--dir <path>]` | Open the analysis dashboard in the browser |
+
+The picker (used by `play "<song>"` and `search --play`) is an arrow-key menu
+(↑/↓ + Enter). In a non-interactive terminal it falls back to a numbered prompt
+(`Play which? [1-N]`, `0` to cancel).
+
+Examples:
+
+```bash
+spoti now
+spoti vol 40
+spoti shuffle on
+spoti transfer "MacBook"
+spoti play "so what miles davis"        # pick from a menu
+spoti play "so what miles davis" -f     # just play the top hit
+spoti search "miles davis"              # list only
+spoti search "kind of blue" --type album --play
+```
+
+---
+
+## Playlist analysis
+
+### 1 · Export a playlist
+
+`playlist-export` writes every track in a playlist to a JSON file. Pass a
+search query, a Spotify URI, a share URL, or a raw playlist ID:
+
+```bash
+spoti playlist-export "corremo"
+spoti playlist-export spotify:playlist:6daUP1z3VZCaDFcatFd8gW
+spoti playlist-export 6daUP1z3VZCaDFcatFd8gW --output ~/data/corremo.json
+spoti playlist-export "lofi" --no-audio-features   # skip the feature fetch
+```
+
+The file is self-contained — it includes track metadata and attempts to embed
+Spotify audio features (BPM, energy, etc.) per track. Those features require
+an extended Spotify app tier; if the request returns 403 the export still
+succeeds but `features` will be `null` per track.
+
+### 2 · Enrich with BPM (GetSongBPM)
+
+Spotify's audio-features endpoint was restricted in November 2024 for most app
+tiers. `enrich-bpm` fetches BPM from [GetSongBPM](https://getsongbpm.com) as an
+alternative and patches the exported JSON in-place.
+
+#### Get a free API key
+
+1. Go to <https://getsongbpm.com/api> and fill in the registration form.
+   - Email: your normal email.
+   - Website: your GitHub repo URL works (`https://github.com/dancps/danfault`).
+2. They'll email you a key.
+3. Add a backlink somewhere visible (their only requirement for the free tier):
+
+   ```markdown
+   BPM data sourced from [GetSongBPM](https://getsongbpm.com).
+   ```
+
+#### Run
+
+```bash
+spoti enrich-bpm corremo.json --api-key YOUR_KEY   # key is saved after first run
+spoti enrich-bpm corremo.json                      # subsequent runs
+spoti enrich-bpm corremo.json --force              # re-fetch even tracks that already have BPM
+spoti enrich-bpm corremo.json --delay 0.5          # slow down if hitting rate limits
+```
+
+The key is persisted to `~/.config/danfault/spotify.json`.
+
+#### BPM cache
+
+Lookups are cached in `~/.config/danfault/bpm_cache.json` keyed by
+`"artist|title"`. Running `enrich-bpm` on a second playlist that shares tracks
+will not re-query the API for those tracks — it reads from the cache instead.
+
+### 3 · Dashboard (`spoti ui`)
+
+A React/Vite dashboard with two tabs:
+- **Library** — all exported `.json` files in the directory.
+- **Analysis** — artist distribution, BPM histogram, and BPM-over-playlist
+  charts for the selected playlist.
+
+#### First-time build
+
+```bash
+cd python/danfault/spoti-ui
+npm install
+npm run build
+```
+
+#### Run
+
+```bash
+cd ~/data          # wherever your exported .json files are
+spoti ui           # opens http://127.0.0.1:8889 in the browser
+spoti ui --dir ~/data --port 8889   # explicit options
+```
+
+#### Dev mode (hot reload)
+
+Two terminals:
+
+```bash
+# Terminal 1 — Python API server only
+spoti ui --dev
+
+# Terminal 2 — Vite dev server
+cd python/danfault/spoti-ui && npm run dev
+```
+
+Visit `http://localhost:5173`. Changes to `.jsx` files reload instantly.
+
+---
+
+## Data files
+
+### Playlist JSON — `<playlist_name>.json`
+
+Written by `playlist-export`, patched by `enrich-bpm`.
+
+```
+{
+  "playlist": {
+    "id", "name", "description", "owner", "total", "snapshot_id"
+  },
+  "tracks": [
+    {
+      "added_at":    "2026-06-13T15:31:48Z",
+      "id":          "spotify track ID",
+      "name":        "Track Title",
+      "uri":         "spotify:track:...",
+      "duration_ms": 230880,
+      "popularity":  41,
+      "explicit":    false,
+      "artists":     [{ "id": "...", "name": "Artist" }],
+      "album":       { "id": "...", "name": "Album", "release_date": "2006-06-01" },
+      "url":         "https://open.spotify.com/track/...",
+      "features":    { "tempo": 128.4, "energy": 0.82, ... },  // null if unavailable
+      "bpm":         128,        // from GetSongBPM (enrich-bpm)
+      "bpm_source":  "getsongbpm"
+    },
+    ...
+  ]
+}
+```
+
+`features` fields (when available): `tempo`, `energy`, `danceability`, `valence`,
+`loudness`, `acousticness`, `instrumentalness`, `liveness`, `speechiness`,
+`key`, `mode`, `time_signature`.
+
+### BPM cache — `~/.config/danfault/bpm_cache.json`
+
+Shared across all playlists. Keyed by `"artist|title"` (lowercase).
+
+```
+{
+  "fresno|absolutamente nada": {
+    "bpm": 128,
+    "source": "getsongbpm",
+    "artist": "Fresno",
+    "title": "Absolutamente Nada"
+  },
+  ...
+}
+```
+
+---
+
+## Troubleshooting
+
+**`No active device`** — The Web API can only control a device Spotify already
+knows is awake. Open Spotify somewhere (phone, desktop app, web player), then:
+
+```bash
+spoti devices            # see what's available
+spoti transfer "<name>"  # wake/target a device
+```
+
+**Browser didn't open / redirect failed** — Make sure the redirect URI in the
+Developer Dashboard is exactly `http://127.0.0.1:8888/callback`. If port 8888 is
+in use, close whatever is holding it and re-run `spoti login`.
+
+**`INVALID_CLIENT` or auth errors** — The Client ID is wrong or the redirect URI
+doesn't match. Re-copy the Client ID and re-run `spoti login --client-id <id>`.
+
+**Want to start over** — `spoti logout` clears the cached tokens; log in again
+to re-authorize.
+
+**`playlist-export` returns empty / permission error** — You need the playlist
+scopes. Run `spoti login` again (even if already logged in) to pick up
+`playlist-read-private` and `playlist-read-collaborative`.
+
+**Audio features return 403** — Spotify restricted the `/audio-features`
+endpoint in November 2024 for apps not on extended quota. The export will
+succeed but `features` will be `null`. Use `spoti enrich-bpm` to get BPM from
+GetSongBPM instead.
+
+**`enrich-bpm` shows `—` for most tracks** — The search may not be matching.
+Try with `--force` to re-run and inspect the output — fuzzy matching prefers
+tracks where both title and artist overlap. Unusual punctuation or featuring
+credits (e.g. `"Song (feat. X)"`) can reduce match quality.
+
+**UI shows "No exported playlists found"** — Run `spoti ui` from the directory
+that contains your `.json` files, or pass `--dir ~/path/to/jsons`.

--- a/examples/spotify/README.md
+++ b/examples/spotify/README.md
@@ -1,0 +1,12 @@
+# Spotify command examples
+
+Sample output produced by the `spoti` CLI (see [../../docs/spoti.md](../../docs/spoti.md)).
+
+- **`corremo.json`** — a playlist export generated with:
+
+  ```bash
+  spoti playlist-export "corremo" --output examples/spotify/corremo.json
+  ```
+
+  It is committed as a reference for the shape of the export (playlist metadata +
+  per-track fields). It is sample data, not something the tool reads.

--- a/examples/spotify/corremo.json
+++ b/examples/spotify/corremo.json
@@ -1,0 +1,582 @@
+{
+  "playlist": {
+    "id": "6daUP1z3VZCaDFcatFd8gW",
+    "name": "😭😿corremo😿😭",
+    "description": "",
+    "owner": "Danilo Calhes",
+    "total": 26,
+    "snapshot_id": "AAAAH+gcV4GB27A68GN9B4Hj5nXEjSL0"
+  },
+  "tracks": [
+    {
+      "added_at": "2026-06-13T15:31:48Z",
+      "id": "2vNSdBUwupb3WbbJsVEc4d",
+      "name": "Absolutamente Nada",
+      "uri": "spotify:track:2vNSdBUwupb3WbbJsVEc4d",
+      "duration_ms": 230880,
+      "popularity": 41,
+      "explicit": false,
+      "artists": [
+        {
+          "id": "2sFXe6NbmT3k7Qy4N8fE7f",
+          "name": "Fresno"
+        }
+      ],
+      "album": {
+        "id": "3LfBdvxxInsz67JEFGsZnO",
+        "name": "Ciano",
+        "release_date": "2006-06-01"
+      },
+      "url": "https://open.spotify.com/track/2vNSdBUwupb3WbbJsVEc4d"
+    },
+    {
+      "added_at": "2026-06-13T15:35:04Z",
+      "id": "2b0wKFAud3JEcm9Sm2pV3H",
+      "name": "Eu Nunca Fui Embora",
+      "uri": "spotify:track:2b0wKFAud3JEcm9Sm2pV3H",
+      "duration_ms": 185337,
+      "popularity": 45,
+      "explicit": false,
+      "artists": [
+        {
+          "id": "2sFXe6NbmT3k7Qy4N8fE7f",
+          "name": "Fresno"
+        }
+      ],
+      "album": {
+        "id": "518eTaR0LiBmCtyjepuLaB",
+        "name": "Eu Nunca Fui Embora",
+        "release_date": "2024-11-01"
+      },
+      "url": "https://open.spotify.com/track/2b0wKFAud3JEcm9Sm2pV3H"
+    },
+    {
+      "added_at": "2026-06-13T15:31:56Z",
+      "id": "2Anewlbuh2nnlUc0bxIKgU",
+      "name": "Cada Poça Dessa Rua Tem Um Pouco de Minhas Lágrimas",
+      "uri": "spotify:track:2Anewlbuh2nnlUc0bxIKgU",
+      "duration_ms": 354120,
+      "popularity": 49,
+      "explicit": false,
+      "artists": [
+        {
+          "id": "2sFXe6NbmT3k7Qy4N8fE7f",
+          "name": "Fresno"
+        }
+      ],
+      "album": {
+        "id": "3LfBdvxxInsz67JEFGsZnO",
+        "name": "Ciano",
+        "release_date": "2006-06-01"
+      },
+      "url": "https://open.spotify.com/track/2Anewlbuh2nnlUc0bxIKgU"
+    },
+    {
+      "added_at": "2026-06-13T15:31:30Z",
+      "id": "26VzA1ncohB7RMsxpXWaZx",
+      "name": "Quebre As Correntes",
+      "uri": "spotify:track:26VzA1ncohB7RMsxpXWaZx",
+      "duration_ms": 226466,
+      "popularity": 52,
+      "explicit": false,
+      "artists": [
+        {
+          "id": "2sFXe6NbmT3k7Qy4N8fE7f",
+          "name": "Fresno"
+        }
+      ],
+      "album": {
+        "id": "3LfBdvxxInsz67JEFGsZnO",
+        "name": "Ciano",
+        "release_date": "2006-06-01"
+      },
+      "url": "https://open.spotify.com/track/26VzA1ncohB7RMsxpXWaZx"
+    },
+    {
+      "added_at": "2026-06-13T15:33:37Z",
+      "id": "4WZw4CtU9BfMEBHR8KEfRK",
+      "name": "Hoje Sou Trovão",
+      "uri": "spotify:track:4WZw4CtU9BfMEBHR8KEfRK",
+      "duration_ms": 281197,
+      "popularity": 31,
+      "explicit": false,
+      "artists": [
+        {
+          "id": "2sFXe6NbmT3k7Qy4N8fE7f",
+          "name": "Fresno"
+        },
+        {
+          "id": "7HGNYPmbDrMkylWqeFCOIQ",
+          "name": "Caetano Veloso"
+        }
+      ],
+      "album": {
+        "id": "5jfwMd6mGG8rk9qHN7GDoy",
+        "name": "A Sinfonia de Tudo Que Há",
+        "release_date": "2016-10-13"
+      },
+      "url": "https://open.spotify.com/track/4WZw4CtU9BfMEBHR8KEfRK"
+    },
+    {
+      "added_at": "2026-06-13T15:30:24Z",
+      "id": "3Xx8DDgvddsYPnxTH2LXsd",
+      "name": "Desde Quando Você Se Foi",
+      "uri": "spotify:track:3Xx8DDgvddsYPnxTH2LXsd",
+      "duration_ms": 216226,
+      "popularity": 55,
+      "explicit": false,
+      "artists": [
+        {
+          "id": "2sFXe6NbmT3k7Qy4N8fE7f",
+          "name": "Fresno"
+        }
+      ],
+      "album": {
+        "id": "4j5DCqWtUEBoO1AFvgKjKF",
+        "name": "Redenção",
+        "release_date": "2008-01-01"
+      },
+      "url": "https://open.spotify.com/track/3Xx8DDgvddsYPnxTH2LXsd"
+    },
+    {
+      "added_at": "2026-06-13T15:30:24Z",
+      "id": "63QharyMHvx3yteCyRnkii",
+      "name": "Redenção",
+      "uri": "spotify:track:63QharyMHvx3yteCyRnkii",
+      "duration_ms": 227933,
+      "popularity": 50,
+      "explicit": false,
+      "artists": [
+        {
+          "id": "2sFXe6NbmT3k7Qy4N8fE7f",
+          "name": "Fresno"
+        }
+      ],
+      "album": {
+        "id": "4j5DCqWtUEBoO1AFvgKjKF",
+        "name": "Redenção",
+        "release_date": "2008-01-01"
+      },
+      "url": "https://open.spotify.com/track/63QharyMHvx3yteCyRnkii"
+    },
+    {
+      "added_at": "2026-06-13T15:30:59Z",
+      "id": "3vNirK8TosxVKYeZoXpIxv",
+      "name": "Polo",
+      "uri": "spotify:track:3vNirK8TosxVKYeZoXpIxv",
+      "duration_ms": 224333,
+      "popularity": 46,
+      "explicit": false,
+      "artists": [
+        {
+          "id": "2sFXe6NbmT3k7Qy4N8fE7f",
+          "name": "Fresno"
+        }
+      ],
+      "album": {
+        "id": "4j5DCqWtUEBoO1AFvgKjKF",
+        "name": "Redenção",
+        "release_date": "2008-01-01"
+      },
+      "url": "https://open.spotify.com/track/3vNirK8TosxVKYeZoXpIxv"
+    },
+    {
+      "added_at": "2026-06-13T15:30:59Z",
+      "id": "2MQnaXCrhHka2bXF2XBrkG",
+      "name": "Milonga",
+      "uri": "spotify:track:2MQnaXCrhHka2bXF2XBrkG",
+      "duration_ms": 301813,
+      "popularity": 47,
+      "explicit": false,
+      "artists": [
+        {
+          "id": "2sFXe6NbmT3k7Qy4N8fE7f",
+          "name": "Fresno"
+        }
+      ],
+      "album": {
+        "id": "4j5DCqWtUEBoO1AFvgKjKF",
+        "name": "Redenção",
+        "release_date": "2008-01-01"
+      },
+      "url": "https://open.spotify.com/track/2MQnaXCrhHka2bXF2XBrkG"
+    },
+    {
+      "added_at": "2026-06-13T15:32:38Z",
+      "id": "0oWedhi1GJEw3jynKjFaDr",
+      "name": "A Minha História Não Acaba Aqui",
+      "uri": "spotify:track:0oWedhi1GJEw3jynKjFaDr",
+      "duration_ms": 240053,
+      "popularity": 31,
+      "explicit": false,
+      "artists": [
+        {
+          "id": "2sFXe6NbmT3k7Qy4N8fE7f",
+          "name": "Fresno"
+        }
+      ],
+      "album": {
+        "id": "6SH5RNO347OXTrPndPUj52",
+        "name": "Revanche",
+        "release_date": "2010-01-01"
+      },
+      "url": "https://open.spotify.com/track/0oWedhi1GJEw3jynKjFaDr"
+    },
+    {
+      "added_at": "2026-06-13T15:32:38Z",
+      "id": "33Y1jukFR76pj7TXFTHQBJ",
+      "name": "Porto Alegre",
+      "uri": "spotify:track:33Y1jukFR76pj7TXFTHQBJ",
+      "duration_ms": 227973,
+      "popularity": 48,
+      "explicit": false,
+      "artists": [
+        {
+          "id": "2sFXe6NbmT3k7Qy4N8fE7f",
+          "name": "Fresno"
+        }
+      ],
+      "album": {
+        "id": "6SH5RNO347OXTrPndPUj52",
+        "name": "Revanche",
+        "release_date": "2010-01-01"
+      },
+      "url": "https://open.spotify.com/track/33Y1jukFR76pj7TXFTHQBJ"
+    },
+    {
+      "added_at": "2026-06-13T15:32:47Z",
+      "id": "1mkH2pZ8kUwCjeNfUE4drZ",
+      "name": "Infinito",
+      "uri": "spotify:track:1mkH2pZ8kUwCjeNfUE4drZ",
+      "duration_ms": 232278,
+      "popularity": 46,
+      "explicit": false,
+      "artists": [
+        {
+          "id": "2sFXe6NbmT3k7Qy4N8fE7f",
+          "name": "Fresno"
+        }
+      ],
+      "album": {
+        "id": "6wAEkrOV1p38k0tAUxGFGH",
+        "name": "Infinito",
+        "release_date": "2012-11-01"
+      },
+      "url": "https://open.spotify.com/track/1mkH2pZ8kUwCjeNfUE4drZ"
+    },
+    {
+      "added_at": "2026-06-13T15:32:51Z",
+      "id": "66LpfXw0JhxmaWs2RjoqVn",
+      "name": "Maior Que As Muralhas",
+      "uri": "spotify:track:66LpfXw0JhxmaWs2RjoqVn",
+      "duration_ms": 259079,
+      "popularity": 33,
+      "explicit": false,
+      "artists": [
+        {
+          "id": "2sFXe6NbmT3k7Qy4N8fE7f",
+          "name": "Fresno"
+        }
+      ],
+      "album": {
+        "id": "6wAEkrOV1p38k0tAUxGFGH",
+        "name": "Infinito",
+        "release_date": "2012-11-01"
+      },
+      "url": "https://open.spotify.com/track/66LpfXw0JhxmaWs2RjoqVn"
+    },
+    {
+      "added_at": "2026-06-13T15:32:53Z",
+      "id": "5eg601RYHLYUDQssIIfjDt",
+      "name": "Diga, parte 2",
+      "uri": "spotify:track:5eg601RYHLYUDQssIIfjDt",
+      "duration_ms": 266983,
+      "popularity": 51,
+      "explicit": false,
+      "artists": [
+        {
+          "id": "2sFXe6NbmT3k7Qy4N8fE7f",
+          "name": "Fresno"
+        }
+      ],
+      "album": {
+        "id": "6wAEkrOV1p38k0tAUxGFGH",
+        "name": "Infinito",
+        "release_date": "2012-11-01"
+      },
+      "url": "https://open.spotify.com/track/5eg601RYHLYUDQssIIfjDt"
+    },
+    {
+      "added_at": "2026-06-13T15:33:01Z",
+      "id": "4mnZ0uJXtGpPCy0rhWA4PP",
+      "name": "Sobreviver e Acreditar",
+      "uri": "spotify:track:4mnZ0uJXtGpPCy0rhWA4PP",
+      "duration_ms": 233778,
+      "popularity": 29,
+      "explicit": false,
+      "artists": [
+        {
+          "id": "2sFXe6NbmT3k7Qy4N8fE7f",
+          "name": "Fresno"
+        }
+      ],
+      "album": {
+        "id": "6wAEkrOV1p38k0tAUxGFGH",
+        "name": "Infinito",
+        "release_date": "2012-11-01"
+      },
+      "url": "https://open.spotify.com/track/4mnZ0uJXtGpPCy0rhWA4PP"
+    },
+    {
+      "added_at": "2026-06-13T15:34:22Z",
+      "id": "6jl8NySX6HaXGunnIeiI0R",
+      "name": "Natureza Caos",
+      "uri": "spotify:track:6jl8NySX6HaXGunnIeiI0R",
+      "duration_ms": 220020,
+      "popularity": 38,
+      "explicit": false,
+      "artists": [
+        {
+          "id": "2sFXe6NbmT3k7Qy4N8fE7f",
+          "name": "Fresno"
+        }
+      ],
+      "album": {
+        "id": "3GnxxTD6myp5iDR8DWLlqA",
+        "name": "sua alegria foi cancelada",
+        "release_date": "2019-07-05"
+      },
+      "url": "https://open.spotify.com/track/6jl8NySX6HaXGunnIeiI0R"
+    },
+    {
+      "added_at": "2026-06-13T15:34:28Z",
+      "id": "5HSqP55VsE9CnodtZrlXQ5",
+      "name": "Cada Acidente",
+      "uri": "spotify:track:5HSqP55VsE9CnodtZrlXQ5",
+      "duration_ms": 245916,
+      "popularity": 42,
+      "explicit": false,
+      "artists": [
+        {
+          "id": "2sFXe6NbmT3k7Qy4N8fE7f",
+          "name": "Fresno"
+        },
+        {
+          "id": "3Ujv6sa60JRiaxS8RVuNOj",
+          "name": "Tuyo"
+        }
+      ],
+      "album": {
+        "id": "3GnxxTD6myp5iDR8DWLlqA",
+        "name": "sua alegria foi cancelada",
+        "release_date": "2019-07-05"
+      },
+      "url": "https://open.spotify.com/track/5HSqP55VsE9CnodtZrlXQ5"
+    },
+    {
+      "added_at": "2026-06-13T15:36:02Z",
+      "id": "23UwYzeWY1rRK4iYKywacU",
+      "name": "Era Pra Sempre",
+      "uri": "spotify:track:23UwYzeWY1rRK4iYKywacU",
+      "duration_ms": 269629,
+      "popularity": 43,
+      "explicit": false,
+      "artists": [
+        {
+          "id": "2sFXe6NbmT3k7Qy4N8fE7f",
+          "name": "Fresno"
+        }
+      ],
+      "album": {
+        "id": "518eTaR0LiBmCtyjepuLaB",
+        "name": "Eu Nunca Fui Embora",
+        "release_date": "2024-11-01"
+      },
+      "url": "https://open.spotify.com/track/23UwYzeWY1rRK4iYKywacU"
+    },
+    {
+      "added_at": "2026-06-13T15:40:45Z",
+      "id": "39nffalh5staSsKfmmw1b8",
+      "name": "Diga Parte Final",
+      "uri": "spotify:track:39nffalh5staSsKfmmw1b8",
+      "duration_ms": 312468,
+      "popularity": 42,
+      "explicit": false,
+      "artists": [
+        {
+          "id": "2sFXe6NbmT3k7Qy4N8fE7f",
+          "name": "Fresno"
+        },
+        {
+          "id": "2oyiy3RLv9ifDElGUBHqL3",
+          "name": "CATTO"
+        }
+      ],
+      "album": {
+        "id": "518eTaR0LiBmCtyjepuLaB",
+        "name": "Eu Nunca Fui Embora",
+        "release_date": "2024-11-01"
+      },
+      "url": "https://open.spotify.com/track/39nffalh5staSsKfmmw1b8"
+    },
+    {
+      "added_at": "2026-06-13T15:40:55Z",
+      "id": "3uOTcfBzKJqlaKe5L6ZBzu",
+      "name": "Camadas",
+      "uri": "spotify:track:3uOTcfBzKJqlaKe5L6ZBzu",
+      "duration_ms": 228000,
+      "popularity": 30,
+      "explicit": false,
+      "artists": [
+        {
+          "id": "2sFXe6NbmT3k7Qy4N8fE7f",
+          "name": "Fresno"
+        },
+        {
+          "id": "7gfkYbxpguEc9bm6m8TpAr",
+          "name": "Chitãozinho & Xororó"
+        }
+      ],
+      "album": {
+        "id": "518eTaR0LiBmCtyjepuLaB",
+        "name": "Eu Nunca Fui Embora",
+        "release_date": "2024-11-01"
+      },
+      "url": "https://open.spotify.com/track/3uOTcfBzKJqlaKe5L6ZBzu"
+    },
+    {
+      "added_at": "2026-06-13T15:41:03Z",
+      "id": "6U91dUDUCllToKsXq2y8yb",
+      "name": "Eu Não Vou Deixar Você Morrer",
+      "uri": "spotify:track:6U91dUDUCllToKsXq2y8yb",
+      "duration_ms": 211080,
+      "popularity": 55,
+      "explicit": false,
+      "artists": [
+        {
+          "id": "2sFXe6NbmT3k7Qy4N8fE7f",
+          "name": "Fresno"
+        }
+      ],
+      "album": {
+        "id": "33vakWPP6Ze0sxf8A5kcss",
+        "name": "Carta de Adeus",
+        "release_date": "2026-04-24"
+      },
+      "url": "https://open.spotify.com/track/6U91dUDUCllToKsXq2y8yb"
+    },
+    {
+      "added_at": "2026-06-13T15:41:13Z",
+      "id": "5Vo7wzXoXyJzKhUnWWystj",
+      "name": "Carta de Adeus (BYE BYE TCHAU)",
+      "uri": "spotify:track:5Vo7wzXoXyJzKhUnWWystj",
+      "duration_ms": 212880,
+      "popularity": 55,
+      "explicit": false,
+      "artists": [
+        {
+          "id": "2sFXe6NbmT3k7Qy4N8fE7f",
+          "name": "Fresno"
+        }
+      ],
+      "album": {
+        "id": "33vakWPP6Ze0sxf8A5kcss",
+        "name": "Carta de Adeus",
+        "release_date": "2026-04-24"
+      },
+      "url": "https://open.spotify.com/track/5Vo7wzXoXyJzKhUnWWystj"
+    },
+    {
+      "added_at": "2026-06-13T15:43:46Z",
+      "id": "4x7OZJzLzYfPCir3PvND29",
+      "name": "Tentar De Novo e De Novo",
+      "uri": "spotify:track:4x7OZJzLzYfPCir3PvND29",
+      "duration_ms": 254832,
+      "popularity": 56,
+      "explicit": false,
+      "artists": [
+        {
+          "id": "2sFXe6NbmT3k7Qy4N8fE7f",
+          "name": "Fresno"
+        }
+      ],
+      "album": {
+        "id": "33vakWPP6Ze0sxf8A5kcss",
+        "name": "Carta de Adeus",
+        "release_date": "2026-04-24"
+      },
+      "url": "https://open.spotify.com/track/4x7OZJzLzYfPCir3PvND29"
+    },
+    {
+      "added_at": "2026-06-13T15:43:52Z",
+      "id": "4pjaCwLLLmin1rmJBwhA6R",
+      "name": "Pessoa",
+      "uri": "spotify:track:4pjaCwLLLmin1rmJBwhA6R",
+      "duration_ms": 221690,
+      "popularity": 53,
+      "explicit": false,
+      "artists": [
+        {
+          "id": "2sFXe6NbmT3k7Qy4N8fE7f",
+          "name": "Fresno"
+        }
+      ],
+      "album": {
+        "id": "33vakWPP6Ze0sxf8A5kcss",
+        "name": "Carta de Adeus",
+        "release_date": "2026-04-24"
+      },
+      "url": "https://open.spotify.com/track/4pjaCwLLLmin1rmJBwhA6R"
+    },
+    {
+      "added_at": "2026-06-13T16:00:04Z",
+      "id": "5B5eTk7DF8KVp1zpQoY1XY",
+      "name": "The Reason",
+      "uri": "spotify:track:5B5eTk7DF8KVp1zpQoY1XY",
+      "duration_ms": 232800,
+      "popularity": 87,
+      "explicit": false,
+      "artists": [
+        {
+          "id": "2MqhkhX4npxDZ62ObR5ELO",
+          "name": "Hoobastank"
+        }
+      ],
+      "album": {
+        "id": "3pCVjmRGVZ2mYuJN2R1wi8",
+        "name": "The Reason (20th Anniversary)",
+        "release_date": "2024-01-12"
+      },
+      "url": "https://open.spotify.com/track/5B5eTk7DF8KVp1zpQoY1XY"
+    },
+    {
+      "added_at": "2026-06-13T16:39:51Z",
+      "id": "6wJqQmyHqINC6aRm6iYsku",
+      "name": "Manifesto (feat. Lenine & Emicida)",
+      "uri": "spotify:track:6wJqQmyHqINC6aRm6iYsku",
+      "duration_ms": 274145,
+      "popularity": 43,
+      "explicit": false,
+      "artists": [
+        {
+          "id": "2sFXe6NbmT3k7Qy4N8fE7f",
+          "name": "Fresno"
+        },
+        {
+          "id": "4YLBdrR3DVSMncm785NH6C",
+          "name": "Lenine"
+        },
+        {
+          "id": "2d9LRvQJnAXRijqIJDDs2K",
+          "name": "Emicida"
+        }
+      ],
+      "album": {
+        "id": "2RhCVgGIB5dd4k8z8rsdYe",
+        "name": "Eu Sou a Maré Viva",
+        "release_date": "2014-03-31"
+      },
+      "url": "https://open.spotify.com/track/6wJqQmyHqINC6aRm6iYsku"
+    }
+  ]
+}

--- a/python/danfault/danfault/arc-folder-to-markdown-plan.md
+++ b/python/danfault/danfault/arc-folder-to-markdown-plan.md
@@ -1,0 +1,84 @@
+# Plan: Arc sidebar folder → Markdown list
+
+## Goal
+Build a small command-line tool that reads my **Arc browser** sidebar data and prints (or saves) a **Markdown list of the tabs inside a named folder**, including nested subfolders. Each tab becomes a `- [Title](URL)` line. Subfolders become nested list items.
+
+This must work on folders even when their tabs are not currently open, so it reads Arc's saved sidebar data on disk rather than the live tab API. (Arc's sidebar folders are not standard Chrome tab groups or bookmarks, so a Chrome extension can't see them cleanly — that's why this is a local script.)
+
+## Constraints / preferences
+- **Python 3, standard library only.** No pip installs. Single self-contained script.
+- Read-only with respect to Arc's data: never modify the original file. Work on a copy.
+- Don't require Arc to be running.
+
+## IMPORTANT: inspect the real data before writing the parser
+Arc's on-disk format is undocumented and the exact field names vary by version, so **do not assume the schema from this plan**. Before writing parsing logic:
+
+1. Locate the data file (see paths below).
+2. Copy it to the working directory.
+3. Load it and print: the top-level keys, the shape of `sidebar` / `containers`, and 3–5 sample entries from the flat item list (pretty-printed JSON, truncated).
+4. From those samples, work out empirically how the format distinguishes: **spaces**, **folders**, and **tabs**, and where the tab **URL** and **title** live, and how parent/child relationships are encoded (e.g. `childrenIds` arrays and/or `parentID`).
+5. Only then write the parser against the structure you actually observed. Show me the sample output so I can confirm before you finalize.
+
+## Where the data lives
+The file is `StorableSidebar.json`. Detect the OS and search these locations (expand `~` / env vars):
+
+- **macOS:** `~/Library/Application Support/Arc/StorableSidebar.json`
+- **Windows:** under `%LOCALAPPDATA%\Packages\TheBrowserCompany.Arc_*\LocalCache\Local\Arc\StorableSidebar.json` (glob the package folder)
+
+If not found, print the paths you checked and let me pass an explicit `--file PATH`.
+
+## How the format is (probably) shaped — verify against step "inspect"
+Expect a flat list of items each with an `id`, a parent reference, and a `childrenIds` list. Items are one of:
+- a **tab** (has a saved URL + saved title),
+- a **folder / list** (has a title + children, no URL),
+- a **space** (top-level grouping; has a name and links to pinned/unpinned containers).
+
+Rebuild the tree by indexing every item by `id`, then walking `childrenIds`. Treat the same recursion for folders nested in folders.
+
+## CLI interface
+```
+arc_md.py --list [--file PATH]
+    List every folder found, grouped by space, with full path and tab count.
+    Disambiguates folders that share a name across spaces.
+
+arc_md.py "Folder Name" [--space "Space Name"] [--out output.md] [--headings] [--file PATH]
+    Print the Markdown for that folder to stdout, or write to --out.
+    --space narrows the match when a folder name is not unique.
+    --headings renders each subfolder as a Markdown heading (###) instead of a nested bullet.
+```
+
+## Output format
+Default (nested bullets):
+```markdown
+- [Anthropic](https://anthropic.com)
+- [Docs](https://docs.claude.com)
+- Subfolder name
+  - [Nested tab](https://example.com)
+```
+
+With `--headings`, top-level folder name becomes an `##` heading, each subfolder a `###`, and tabs are flat bullets under their heading.
+
+Escape Markdown-significant characters in titles (`[`, `]`, `|`, backticks). Keep any emoji in folder/tab titles as-is. Skip items with no resolvable URL but log how many were skipped.
+
+## Edge cases to handle
+- Folder name not found → print the closest matches and exit non-zero.
+- Folder name not unique and no `--space` given → list the candidates with their spaces and ask me to disambiguate.
+- Archived / suspended tabs that still have a saved URL → include them.
+- Empty folder → emit a note, not a crash.
+- Malformed or unexpected JSON → fail with a clear message, not a stack trace.
+
+## Acceptance criteria
+1. `--list` shows my real folders grouped by space with correct counts.
+2. Running it on one real folder produces Markdown whose links open the right pages.
+3. Nested subfolders are represented correctly in both default and `--headings` modes.
+4. Original `StorableSidebar.json` is untouched.
+5. Single file, runs with `python3 arc_md.py ...`, no external dependencies.
+
+## Suggested build order
+1. File location + `--file` override + copy-to-workdir.
+2. Load + inspect/print samples (share with me to confirm schema).
+3. Index items, rebuild tree, classify spaces/folders/tabs.
+4. `--list` command.
+5. Folder lookup (+ `--space` disambiguation) and recursive Markdown rendering.
+6. `--out` and `--headings` options, escaping, edge cases.
+7. Run against my real data and show output.

--- a/python/danfault/danfault/arc.py
+++ b/python/danfault/danfault/arc.py
@@ -1,0 +1,504 @@
+"""Export Arc browser sidebar folders/spaces to Markdown link lists.
+
+Arc stores its sidebar (spaces, folders, tabs) in an undocumented JSON file,
+``StorableSidebar.json`` — not the live tab API — so this reads that file from
+disk and rebuilds the tree. The original file is never modified; parsing works
+on a temp copy.
+
+CLI (wired into the main ``danfault`` app under ``arc``)::
+
+    danfault arc tabs list
+    danfault arc tabs backup ["Folder Name"] [--space ..] [--out ..] [--clipboard] [--headings] [--file ..]
+
+The parsing layer below is pure standard library; only the CLI uses Typer.
+"""
+
+import glob
+import json
+import os
+import platform
+import shutil
+import subprocess
+import sys
+import tempfile
+from difflib import get_close_matches
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import typer
+
+from danfault.logs import Loggir
+
+log = Loggir()
+
+# ──────────────────────────────────────────────────────────────────────────
+# File location
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _candidate_paths() -> List[Path]:
+    """Return the platform-specific locations to search for StorableSidebar.json."""
+    system = platform.system()
+    if system == "Darwin":
+        return [Path.home() / "Library" / "Application Support" / "Arc" / "StorableSidebar.json"]
+    if system == "Windows":
+        local = os.environ.get("LOCALAPPDATA", "")
+        pattern = os.path.join(
+            local,
+            "Packages",
+            "TheBrowserCompany.Arc_*",
+            "LocalCache",
+            "Local",
+            "Arc",
+            "StorableSidebar.json",
+        )
+        return [Path(p) for p in glob.glob(pattern)]
+    # Linux / unknown: Arc isn't officially available, but try a sensible default.
+    return [Path.home() / ".config" / "Arc" / "StorableSidebar.json"]
+
+
+def locate_sidebar_file(explicit: Optional[str] = None) -> Path:
+    """Resolve the sidebar file, honoring an explicit ``--file`` override.
+
+    Raises FileNotFoundError (with the paths checked) if nothing is found.
+    """
+    if explicit:
+        p = Path(explicit).expanduser()
+        if not p.is_file():
+            raise FileNotFoundError(f"--file path does not exist: {p}")
+        return p
+
+    candidates = _candidate_paths()
+    for c in candidates:
+        if c.is_file():
+            return c
+
+    checked = "\n".join(f"  - {c}" for c in candidates) or "  (none for this OS)"
+    raise FileNotFoundError(
+        "Could not find Arc's StorableSidebar.json. Checked:\n"
+        f"{checked}\nPass an explicit path with --file PATH."
+    )
+
+
+def load_sidebar(path: Path) -> dict:
+    """Load the sidebar JSON from a temp copy so the original is never touched."""
+    tmp_dir = tempfile.mkdtemp(prefix="danfault_arc_")
+    tmp_file = Path(tmp_dir) / "StorableSidebar.json"
+    try:
+        shutil.copy2(path, tmp_file)
+        with open(tmp_file, "r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{path} is not valid JSON: {exc}") from None
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Model building
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _dicts(seq) -> List[dict]:
+    """From Arc's marker+dict alternating list, return the dict elements in order."""
+    if not isinstance(seq, list):
+        return []
+    return [x for x in seq if isinstance(x, dict)]
+
+
+def is_tab(item: dict) -> bool:
+    data = item.get("data")
+    return isinstance(data, dict) and "tab" in data
+
+
+def is_folder(item: dict) -> bool:
+    data = item.get("data")
+    return isinstance(data, dict) and "list" in data
+
+
+def is_container(item: dict) -> bool:
+    data = item.get("data")
+    return isinstance(data, dict) and "itemContainer" in data
+
+
+class Space:
+    def __init__(self, title: str, space_id: str, root_ids: List[str]):
+        self.title = title
+        self.id = space_id
+        self.root_ids = root_ids
+
+
+class Model:
+    def __init__(self, items_by_id: Dict[str, dict], spaces: List[Space]):
+        self.items_by_id = items_by_id
+        self.spaces = spaces
+
+
+def _resolve_root_ids(space: dict, items_by_id: Dict[str, dict]) -> List[str]:
+    """Pull the container ids out of a space's containerIDs / newContainerIDs.
+
+    The list interleaves marker strings ("pinned"/"unpinned") with the actual
+    ids; we just keep the entries that exist as items (the itemContainer roots).
+    """
+    roots: List[str] = []
+    for key in ("containerIDs", "newContainerIDs"):
+        for entry in space.get(key, []) or []:
+            if isinstance(entry, str) and entry in items_by_id and entry not in roots:
+                roots.append(entry)
+    return roots
+
+
+def build_model(data: dict) -> Model:
+    """Index all items by id and build the ordered list of spaces."""
+    sidebar = data.get("sidebar", {})
+    containers = sidebar.get("containers", [])
+    if not isinstance(containers, list):
+        raise ValueError("Unexpected sidebar format: 'containers' is not a list.")
+
+    # Pick the richest data-bearing container (the one with the most items).
+    data_containers = [c for c in containers if isinstance(c, dict) and "items" in c]
+    if not data_containers:
+        raise ValueError("Unexpected sidebar format: no container with 'items' found.")
+    container = max(data_containers, key=lambda c: len(c.get("items", [])))
+
+    items_by_id: Dict[str, dict] = {}
+    for item in _dicts(container.get("items", [])):
+        item_id = item.get("id")
+        if item_id:
+            items_by_id[item_id] = item
+
+    spaces: List[Space] = []
+    for sp in _dicts(container.get("spaces", [])):
+        title = sp.get("title") or "(untitled space)"
+        spaces.append(Space(title, sp.get("id", ""), _resolve_root_ids(sp, items_by_id)))
+
+    return Model(items_by_id, spaces)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Tree walking
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _tab_title(item: dict) -> str:
+    tab = item.get("data", {}).get("tab", {})
+    return item.get("title") or tab.get("savedTitle") or tab.get("savedURL") or ""
+
+
+def walk(item_id: str, items_by_id: Dict[str, dict], skipped: List[int]) -> Optional[dict]:
+    """Build a node tree from an item id.
+
+    Returns a node dict: a folder ``{"type":"folder","title","children":[...]}``
+    or a tab ``{"type":"tab","title","url"}``. Tabs with no saved URL are skipped
+    (counted in ``skipped``). Container roots are transparent — their children are
+    returned as folder children.
+    """
+    item = items_by_id.get(item_id)
+    if item is None:
+        return None
+
+    if is_tab(item):
+        url = item.get("data", {}).get("tab", {}).get("savedURL")
+        if not url:
+            skipped[0] += 1
+            return None
+        return {"type": "tab", "title": _tab_title(item), "url": url}
+
+    # Folder or container: recurse into children.
+    children: List[dict] = []
+    for child_id in item.get("childrenIds", []) or []:
+        node = walk(child_id, items_by_id, skipped)
+        if node is not None:
+            children.append(node)
+    title = item.get("title") or ""
+    return {"type": "folder", "title": title, "children": children}
+
+
+def _children_nodes(root_ids: List[str], items_by_id: Dict[str, dict], skipped: List[int]) -> List[dict]:
+    """Flatten the children of a set of container roots into a node list."""
+    nodes: List[dict] = []
+    for rid in root_ids:
+        node = walk(rid, items_by_id, skipped)
+        if node and node["type"] == "folder":
+            nodes.extend(node["children"])
+        elif node:
+            nodes.append(node)
+    return nodes
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Folder discovery
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _count_tabs(node: dict) -> int:
+    if node["type"] == "tab":
+        return 1
+    return sum(_count_tabs(c) for c in node["children"])
+
+
+def find_folders(model: Model) -> List[dict]:
+    """Return every folder as ``{space, path, name, node, tab_count}`` in display order."""
+    found: List[dict] = []
+
+    def recurse(nodes: List[dict], space_title: str, prefix: List[str]):
+        for node in nodes:
+            if node["type"] != "folder":
+                continue
+            name = node["title"] or "(untitled)"
+            path = prefix + [name]
+            found.append(
+                {
+                    "space": space_title,
+                    "path": path,
+                    "name": name,
+                    "node": node,
+                    "tab_count": _count_tabs(node),
+                }
+            )
+            recurse(node["children"], space_title, path)
+
+    for space in model.spaces:
+        skipped = [0]
+        top = _children_nodes(space.root_ids, model.items_by_id, skipped)
+        recurse(top, space.title, [])
+    return found
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Markdown rendering
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _escape(text: str) -> str:
+    """Escape Markdown-significant characters in a title (emoji preserved)."""
+    for ch in ("\\", "`", "[", "]", "|"):
+        text = text.replace(ch, "\\" + ch)
+    return text
+
+
+def render_markdown(node: dict, headings: bool = False) -> str:
+    """Render a folder node (or a synthetic root) to Markdown.
+
+    Default: nested bullets. With ``headings=True`` the root folder becomes an
+    ``##`` heading, subfolders ``###`` (capped at ######), and tabs are flat bullets.
+    """
+    lines: List[str] = []
+
+    def bullets(children: List[dict], depth: int):
+        indent = "  " * depth
+        for child in children:
+            if child["type"] == "tab":
+                lines.append(f"{indent}- [{_escape(child['title'])}]({child['url']})")
+            else:
+                lines.append(f"{indent}- {_escape(child['title'] or '(untitled)')}")
+                bullets(child["children"], depth + 1)
+
+    def headed(folder: dict, level: int):
+        hashes = "#" * min(level, 6)
+        title = _escape(folder["title"] or "(untitled)")
+        lines.append(f"{hashes} {title}")
+        lines.append("")
+        tabs = [c for c in folder["children"] if c["type"] == "tab"]
+        subs = [c for c in folder["children"] if c["type"] == "folder"]
+        for tab in tabs:
+            lines.append(f"- [{_escape(tab['title'])}]({tab['url']})")
+        if tabs:
+            lines.append("")
+        for sub in subs:
+            headed(sub, level + 1)
+
+    if headings:
+        headed(node, 1)
+    else:
+        # Lead with the folder/space name as a header, then its contents as bullets.
+        lines.append(f"# {_escape(node['title'] or '(untitled)')}")
+        lines.append("")
+        bullets(node["children"], 0)
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Output helpers
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _copy_to_clipboard(text: str) -> None:
+    """Copy text to the system clipboard (pbcopy/xclip/clip), raising on failure."""
+    system = platform.system()
+    if system == "Darwin":
+        cmd = ["pbcopy"]
+    elif system == "Windows":
+        cmd = ["clip"]
+    else:
+        cmd = ["xclip", "-selection", "clipboard"]
+    try:
+        proc = subprocess.run(cmd, input=text.encode("utf-8"), check=True)
+        _ = proc
+    except (FileNotFoundError, subprocess.CalledProcessError) as exc:
+        raise RuntimeError(f"Could not copy to clipboard ({' '.join(cmd)}): {exc}") from None
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# CLI
+# ──────────────────────────────────────────────────────────────────────────
+
+arc_app = typer.Typer(help="Arc browser utilities.")
+tabs_app = typer.Typer(help="Export Arc sidebar folders/spaces to Markdown.")
+arc_app.add_typer(tabs_app, name="tabs")
+
+
+def _load_model(file: Optional[str]) -> Model:
+    """Locate + load + build the model, exiting cleanly on known errors."""
+    try:
+        path = locate_sidebar_file(file)
+        data = load_sidebar(path)
+        return build_model(data)
+    except (FileNotFoundError, ValueError) as exc:
+        log.error(str(exc))
+        raise typer.Exit(code=1)
+
+
+@tabs_app.command("list")
+def list_tabs(
+    space: Optional[str] = typer.Option(
+        None, "--space", help="List folders in this space (defaults to the first space)."
+    ),
+    all_spaces: bool = typer.Option(False, "--all", help="List folders across every space."),
+    file: Optional[str] = typer.Option(None, "--file", help="Explicit path to StorableSidebar.json."),
+):
+    """List the contents of a space as a tree: folders as headings, tabs as bullets.
+
+    Each folder heading is annotated with its recursive tab count, e.g.
+    ``## Databricks  [10 tab(s)]``; nesting depth maps to heading level. Without
+    flags, lists the first space; ``--space NAME`` picks another. With ``--all``,
+    lists every space in parse order — which should match your Arc sidebar order
+    (validation step). ``--all`` and ``--space`` are mutually exclusive.
+    """
+    if all_spaces and space:
+        log.error("--all and --space cannot be used together.")
+        raise typer.Exit(code=1)
+
+    model = _load_model(file)
+
+    def _print_node(node: dict, level: int):
+        hashes = "#" * min(level, 6)
+        typer.echo(f"{hashes} {_escape(node['title'] or '(untitled)')}  [{_count_tabs(node)} tab(s)]")
+        tabs = [c for c in node["children"] if c["type"] == "tab"]
+        subs = [c for c in node["children"] if c["type"] == "folder"]
+        for t in tabs:
+            typer.echo(f"- [{_escape(t['title'])}]({t['url']})")
+        if not node["children"]:
+            typer.echo("_(empty)_")
+        typer.echo("")
+        for s in subs:
+            _print_node(s, level + 1)
+
+    if all_spaces:
+        typer.echo("Spaces (in parse order — confirm this matches your Arc sidebar):")
+        for i, sp in enumerate(model.spaces, start=1):
+            typer.echo(f"  {i}. {sp.title}")
+        typer.echo("")
+        for sp in model.spaces:
+            _print_node(_space_root_node(model, sp), 1)
+        return
+
+    target = _find_space(model, space, action="listing")
+    _print_node(_space_root_node(model, target), 1)
+
+
+def _find_space(model: Model, space_name: Optional[str], action: str = "backing up") -> Space:
+    if space_name:
+        matches = [s for s in model.spaces if s.title.lower() == space_name.lower()]
+        if not matches:
+            names = ", ".join(repr(s.title) for s in model.spaces)
+            log.error(f"Space {space_name!r} not found. Available spaces: {names}")
+            raise typer.Exit(code=1)
+        return matches[0]
+    # Default to the first space.
+    if not model.spaces:
+        log.error("No spaces found in the sidebar data.")
+        raise typer.Exit(code=1)
+    chosen = model.spaces[0]
+    log.warning(
+        f"No space given; {action} the first space: {chosen.title!r}. "
+        "Run `danfault arc tabs list --all` to confirm this matches your Arc sidebar order."
+    )
+    return chosen
+
+
+def _space_root_node(model: Model, space: Space) -> dict:
+    """Build a synthetic folder node holding all of a space's top-level items."""
+    skipped = [0]
+    children = _children_nodes(space.root_ids, model.items_by_id, skipped)
+    if skipped[0]:
+        log.warning(f"Skipped {skipped[0]} tab(s) with no saved URL.")
+    return {"type": "folder", "title": space.title, "children": children}
+
+
+def _resolve_folder_node(model: Model, folder: str, space_name: Optional[str]) -> dict:
+    """Find a folder by name, disambiguating by space; exit cleanly on errors."""
+    folders = find_folders(model)
+    matches = [f for f in folders if f["name"].lower() == folder.lower()]
+    if space_name:
+        matches = [f for f in matches if f["space"].lower() == space_name.lower()]
+
+    if not matches:
+        all_names = [f["name"] for f in folders]
+        close = get_close_matches(folder, all_names, n=5)
+        log.error(f"Folder {folder!r} not found.")
+        if close:
+            log.error("Closest matches: " + ", ".join(repr(c) for c in close))
+        raise typer.Exit(code=1)
+
+    if len(matches) > 1:
+        log.error(f"Folder {folder!r} is not unique. Candidates (use --space to disambiguate):")
+        for m in matches:
+            log.error(f"  - {m['space']}: {' / '.join(m['path'])}")
+        raise typer.Exit(code=1)
+
+    return matches[0]["node"]
+
+
+@tabs_app.command("backup")
+def backup_tabs(
+    folder: Optional[str] = typer.Argument(
+        None, help="Folder name to export. Omit to export the whole space."
+    ),
+    space: Optional[str] = typer.Option(None, "--space", help="Space name (for disambiguation / selection)."),
+    out: Optional[str] = typer.Option(None, "--out", help="Write Markdown to this file instead of stdout."),
+    clipboard: bool = typer.Option(False, "--clipboard", help="Copy Markdown to the clipboard."),
+    headings: bool = typer.Option(False, "--headings", help="Render subfolders as headings, not nested bullets."),
+    file: Optional[str] = typer.Option(None, "--file", help="Explicit path to StorableSidebar.json."),
+):
+    """Export an Arc folder (or a whole space) to a Markdown link list."""
+    model = _load_model(file)
+
+    if folder:
+        node = _resolve_folder_node(model, folder, space)
+    else:
+        node = _space_root_node(model, _find_space(model, space))
+
+    if not node["children"]:
+        log.warning(f"{node['title']!r} is empty — nothing to export.")
+
+    markdown = render_markdown(node, headings=headings)
+
+    if out:
+        Path(out).expanduser().write_text(markdown, encoding="utf-8")
+        log.info(f"Wrote {len(markdown.splitlines())} line(s) to {out}")
+    if clipboard:
+        try:
+            _copy_to_clipboard(markdown)
+            log.info(f"Copied {len(markdown.splitlines())} line(s) to clipboard.")
+        except RuntimeError as exc:
+            log.error(str(exc))
+            raise typer.Exit(code=1)
+    if not out and not clipboard:
+        # Default: stdout (pipe-friendly, no log noise on the data stream).
+        sys.stdout.write(markdown)
+
+
+if __name__ == "__main__":
+    arc_app()

--- a/python/danfault/danfault/main.py
+++ b/python/danfault/danfault/main.py
@@ -2,10 +2,16 @@ from danfault.logs import Loggir
 import os
 import typer
 from danfault import csvutils
+from danfault import arc
+from danfault import spotify
+from danfault import vault
 app = typer.Typer()
 
 # Optionally, you can add commands to the app here or in other modules and import them.
 app.add_typer(csvutils.app, name="csv")
+app.add_typer(arc.arc_app, name="arc")
+app.add_typer(spotify.app, name="spotify")
+app.add_typer(vault.app, name="vault")
 
 @app.command()
 def hello_world():

--- a/python/danfault/danfault/spotify.py
+++ b/python/danfault/danfault/spotify.py
@@ -1,0 +1,1289 @@
+"""Control Spotify from the command line via the Spotify Web API.
+
+Unlike ``dbus-send`` (Linux-only) or AppleScript (controls only the local Mac
+app), the Web API can drive *any* of your devices — laptop, phone, speakers.
+
+Auth is OAuth 2.0 **Authorization Code with PKCE**: ``spoti login`` opens your
+browser, you click *Accept*, and a tiny local server catches the redirect — no
+copy-pasting. PKCE means there is no client *secret* to store; only a public
+Client ID (from the Spotify Developer Dashboard) is needed. Tokens are cached in
+``~/.config/danfault/spotify.json`` (locked to ``chmod 600``) and refreshed
+silently when they expire.
+
+CLI (installed as the standalone ``spoti`` command, also wired into
+``danfault spotify``)::
+
+    spoti login --client-id <id>     # one-time; then just `spoti login`
+    spoti now
+    spoti play | pause | playpause | next | prev
+    spoti vol 40
+    spoti shuffle on | off
+    spoti repeat track | context | off
+    spoti devices
+    spoti transfer "MacBook"
+    spoti search "miles davis" --play
+    spoti playlist-export "my playlist"
+    spoti playlist-export spotify:playlist:<id> --output tracks.json
+
+See ``docs/spoti.md`` for setup and a full reference.
+"""
+
+import base64
+import hashlib
+import http.server
+import json
+import os
+import re
+import secrets
+import sys
+import threading
+import time
+import urllib.parse
+import webbrowser
+from difflib import get_close_matches
+from pathlib import Path
+from typing import Optional
+
+import requests
+import typer
+
+from danfault.logs import Loggir
+
+log = Loggir()
+
+# ──────────────────────────────────────────────────────────────────────────
+# Constants
+# ──────────────────────────────────────────────────────────────────────────
+
+AUTH_URL = "https://accounts.spotify.com/authorize"
+TOKEN_URL = "https://accounts.spotify.com/api/token"
+API_BASE = "https://api.spotify.com/v1"
+
+GETSONGBPM_API = "https://api.getsongbpm.com"
+
+CALLBACK_PORT = 8888
+REDIRECT_URI = f"http://127.0.0.1:{CALLBACK_PORT}/callback"
+
+SCOPES = (
+    "user-read-playback-state "
+    "user-modify-playback-state "
+    "user-read-currently-playing "
+    "playlist-read-private "
+    "playlist-read-collaborative"
+)
+
+CONFIG_FILE = Path.home() / ".config" / "danfault" / "spotify.json"
+BPM_CACHE_FILE = Path.home() / ".config" / "danfault" / "bpm_cache.json"
+
+# Refresh a little before the access token actually expires.
+_EXPIRY_SKEW = 60  # seconds
+
+app = typer.Typer(help="Control Spotify from the command line (Web API).")
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Config / token storage
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _load_config() -> dict:
+    if CONFIG_FILE.exists():
+        try:
+            return json.loads(CONFIG_FILE.read_text())
+        except (json.JSONDecodeError, OSError):
+            log.warning("Could not read %s; treating as empty.", CONFIG_FILE)
+    return {}
+
+
+def _save_config(data: dict) -> None:
+    """Persist config and lock the file to owner-only (it holds a refresh token)."""
+    CONFIG_FILE.parent.mkdir(parents=True, exist_ok=True)
+    CONFIG_FILE.write_text(json.dumps(data, indent=2))
+    try:
+        os.chmod(CONFIG_FILE, 0o600)
+    except OSError:
+        pass  # Best-effort on filesystems without POSIX perms.
+
+
+def _client_id(explicit: Optional[str] = None) -> str:
+    """Resolve the Client ID: explicit arg → env var → config file."""
+    cid = explicit or os.environ.get("SPOTIFY_CLIENT_ID") or _load_config().get("client_id")
+    if not cid:
+        raise typer.BadParameter(
+            "No Spotify Client ID found. Create an app at "
+            "https://developer.spotify.com/dashboard (redirect URI "
+            f"{REDIRECT_URI}), then run: spoti login --client-id <id>  "
+            "(or set SPOTIFY_CLIENT_ID)."
+        )
+    return cid
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# PKCE + OAuth flow
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _b64url(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+
+def _pkce_pair() -> tuple:
+    """Return (code_verifier, code_challenge) for the PKCE flow."""
+    verifier = _b64url(secrets.token_bytes(64))
+    challenge = _b64url(hashlib.sha256(verifier.encode()).digest())
+    return verifier, challenge
+
+
+class _CallbackHandler(http.server.BaseHTTPRequestHandler):
+    """One-shot handler that captures the ?code= redirect from Spotify."""
+
+    # Filled in by the server instance.
+    result: dict = {}
+
+    def do_GET(self):  # noqa: N802 (stdlib naming)
+        parsed = urllib.parse.urlparse(self.path)
+        if parsed.path != "/callback":
+            self.send_response(404)
+            self.end_headers()
+            return
+        params = urllib.parse.parse_qs(parsed.query)
+        self.server.result = {  # type: ignore[attr-defined]
+            "code": params.get("code", [None])[0],
+            "state": params.get("state", [None])[0],
+            "error": params.get("error", [None])[0],
+        }
+        ok = self.server.result.get("code") and not self.server.result.get("error")
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.end_headers()
+        title = "✓ Authorized" if ok else "✗ Authorization failed"
+        body = "You can close this tab and return to the terminal."
+        self.wfile.write(
+            f"<html><body style='font-family:sans-serif;text-align:center;"
+            f"margin-top:4rem'><h2>{title}</h2><p>{body}</p></body></html>".encode()
+        )
+
+    def log_message(self, *args):  # silence the default stderr logging
+        pass
+
+
+def _run_auth_flow(client_id: str) -> None:
+    verifier, challenge = _pkce_pair()
+    state = secrets.token_urlsafe(16)
+    query = urllib.parse.urlencode(
+        {
+            "client_id": client_id,
+            "response_type": "code",
+            "redirect_uri": REDIRECT_URI,
+            "scope": SCOPES,
+            "state": state,
+            "code_challenge_method": "S256",
+            "code_challenge": challenge,
+        }
+    )
+    url = f"{AUTH_URL}?{query}"
+
+    server = http.server.HTTPServer(("127.0.0.1", CALLBACK_PORT), _CallbackHandler)
+    server.result = {}  # type: ignore[attr-defined]
+
+    log.info("Opening your browser to authorize Spotify…")
+    if not webbrowser.open(url):
+        log.warning("Could not open a browser automatically. Visit this URL:\n%s", url)
+
+    server.handle_request()  # blocks until the single callback arrives
+    server.server_close()
+    result = server.result  # type: ignore[attr-defined]
+
+    if result.get("error"):
+        log.error("Authorization denied: %s", result["error"])
+        raise typer.Exit(code=1)
+    if not result.get("code"):
+        log.error("No authorization code received.")
+        raise typer.Exit(code=1)
+    if result.get("state") != state:
+        log.error("State mismatch — aborting for safety.")
+        raise typer.Exit(code=1)
+
+    resp = requests.post(
+        TOKEN_URL,
+        data={
+            "grant_type": "authorization_code",
+            "code": result["code"],
+            "redirect_uri": REDIRECT_URI,
+            "client_id": client_id,
+            "code_verifier": verifier,
+        },
+        timeout=15,
+    )
+    if resp.status_code != 200:
+        log.error("Token exchange failed (%s): %s", resp.status_code, resp.text)
+        raise typer.Exit(code=1)
+
+    tok = resp.json()
+    cfg = _load_config()
+    cfg.update(
+        {
+            "client_id": client_id,
+            "access_token": tok["access_token"],
+            "refresh_token": tok.get("refresh_token", cfg.get("refresh_token")),
+            "expires_at": time.time() + tok.get("expires_in", 3600),
+        }
+    )
+    _save_config(cfg)
+    log.info("Logged in. Token cached at %s", CONFIG_FILE)
+
+
+def _refresh_access_token() -> str:
+    cfg = _load_config()
+    refresh = cfg.get("refresh_token")
+    if not refresh:
+        log.error("No refresh token. Run: spoti login")
+        raise typer.Exit(code=1)
+
+    resp = requests.post(
+        TOKEN_URL,
+        data={
+            "grant_type": "refresh_token",
+            "refresh_token": refresh,
+            "client_id": _client_id(),
+        },
+        timeout=15,
+    )
+    if resp.status_code != 200:
+        log.error("Token refresh failed (%s): %s. Try: spoti login", resp.status_code, resp.text)
+        raise typer.Exit(code=1)
+
+    tok = resp.json()
+    cfg["access_token"] = tok["access_token"]
+    # Spotify may omit a new refresh token — keep the existing one if so.
+    cfg["refresh_token"] = tok.get("refresh_token", refresh)
+    cfg["expires_at"] = time.time() + tok.get("expires_in", 3600)
+    _save_config(cfg)
+    return cfg["access_token"]
+
+
+def _get_access_token() -> str:
+    cfg = _load_config()
+    if not cfg.get("access_token"):
+        log.error("Not logged in. Run: spoti login --client-id <id>")
+        raise typer.Exit(code=1)
+    if time.time() >= cfg.get("expires_at", 0) - _EXPIRY_SKEW:
+        return _refresh_access_token()
+    return cfg["access_token"]
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# API wrapper
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _api(method: str, path: str, **kwargs):
+    """Call the Web API. Returns parsed JSON, or None for empty/204 responses.
+
+    Handles a 401 by refreshing the token once and retrying, and turns the
+    common "no active device" case into a friendly message.
+    """
+    url = path if path.startswith("http") else f"{API_BASE}{path}"
+
+    def _do(token: str):
+        headers = {"Authorization": f"Bearer {token}", **kwargs.pop("headers", {})}
+        return requests.request(method, url, headers=headers, timeout=15, **kwargs)
+
+    token = _get_access_token()
+    resp = _do(token)
+    if resp.status_code == 401:
+        resp = _do(_refresh_access_token())
+
+    if resp.status_code == 204 or not resp.content:
+        return None
+    if resp.status_code == 404:
+        log.error(
+            "No active device. Open Spotify on a device (then `spoti devices` / "
+            "`spoti transfer <name>`) and try again."
+        )
+        raise typer.Exit(code=1)
+    if resp.status_code >= 400:
+        msg = resp.text
+        try:
+            msg = resp.json().get("error", {}).get("message", msg)
+        except (ValueError, AttributeError):
+            pass
+        log.error("Spotify API error (%s): %s", resp.status_code, msg)
+        raise typer.Exit(code=1)
+
+    try:
+        return resp.json()
+    except ValueError:
+        return None
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Small helpers
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _fmt_track(item: Optional[dict]) -> str:
+    if not item:
+        return "(unknown track)"
+    artists = ", ".join(a["name"] for a in item.get("artists", []))
+    name = item.get("name", "?")
+    album = item.get("album", {}).get("name")
+    return f"{artists} — {name}" + (f"  ({album})" if album else "")
+
+
+def _resolve_device(name: str) -> str:
+    data = _api("GET", "/me/player/devices") or {}
+    devices = data.get("devices", [])
+    if not devices:
+        log.error("No devices found. Open Spotify on a device first.")
+        raise typer.Exit(code=1)
+    by_name = {d["name"]: d["id"] for d in devices}
+    # Exact (case-insensitive) first, then fuzzy.
+    for dname, did in by_name.items():
+        if dname.lower() == name.lower():
+            return did
+    match = get_close_matches(name, list(by_name), n=1, cutoff=0.3)
+    if not match:
+        names = ", ".join(by_name) or "(none)"
+        log.error("No device matching %r. Available: %s", name, names)
+        raise typer.Exit(code=1)
+    return by_name[match[0]]
+
+
+def _search(query: str, type_: str = "track", limit: int = 5) -> list:
+    """Run a catalog search and return the list of result items."""
+    data = _api("GET", "/search", params={"q": query, "type": type_, "limit": limit}) or {}
+    return data.get(f"{type_}s", {}).get("items", [])
+
+
+def _result_label(item: dict, type_: str) -> str:
+    return _fmt_track(item) if type_ == "track" else item.get("name", "?")
+
+
+def _print_results(items: list, type_: str) -> None:
+    for i, item in enumerate(items, 1):
+        typer.echo(f"{i}. {_result_label(item, type_)}")
+
+
+def _pick(items: list, type_: str) -> Optional[dict]:
+    """Let the user choose a result. Arrow-key menu on a TTY, numbered prompt otherwise.
+
+    Returns the chosen item, or None if cancelled.
+    """
+    if sys.stdin.isatty() and sys.stdout.isatty():
+        try:
+            import questionary
+
+            choices = [
+                questionary.Choice(_result_label(it, type_), value=idx)
+                for idx, it in enumerate(items)
+            ]
+            idx = questionary.select("Pick one to play:", choices=choices).ask()
+            return items[idx] if idx is not None else None
+        except ImportError:
+            log.warning(
+                "questionary not installed; using a numbered prompt. "
+                "Install it with: pip install questionary"
+            )
+
+    # Non-interactive (or no questionary): numbered fallback.
+    _print_results(items, type_)
+    sel = typer.prompt(f"Play which? [1-{len(items)}] (0 to cancel)", default=0, type=int)
+    return items[sel - 1] if 1 <= sel <= len(items) else None
+
+
+def _play_item(item: dict, type_: str) -> None:
+    if type_ == "track":
+        _api("PUT", "/me/player/play", json={"uris": [item["uri"]]})
+    else:
+        _api("PUT", "/me/player/play", json={"context_uri": item["uri"]})
+    log.info("▶ playing %s", _result_label(item, type_))
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Commands
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@app.command()
+def login(client_id: Optional[str] = typer.Option(None, "--client-id", help="Spotify app Client ID")):
+    """Authorize via the browser and cache tokens locally."""
+    cid = _client_id(client_id)
+    if client_id:
+        cfg = _load_config()
+        cfg["client_id"] = client_id
+        _save_config(cfg)
+    _run_auth_flow(cid)
+
+
+@app.command()
+def logout():
+    """Delete the cached tokens."""
+    if CONFIG_FILE.exists():
+        CONFIG_FILE.unlink()
+        log.info("Removed %s", CONFIG_FILE)
+    else:
+        log.info("Nothing to remove.")
+
+
+@app.command()
+def now():
+    """Show the currently playing track."""
+    data = _api("GET", "/me/player/currently-playing")
+    if not data or not data.get("item"):
+        log.info("Nothing playing.")
+        return
+    state = "▶ playing" if data.get("is_playing") else "⏸ paused"
+    device = (data.get("device") or {}).get("name", "")
+    typer.echo(f"{state}  {_fmt_track(data['item'])}" + (f"  @ {device}" if device else ""))
+
+
+@app.command()
+def play(
+    song: Optional[str] = typer.Argument(None, help="Song to search and play; omit to resume"),
+    first: bool = typer.Option(False, "--first", "-f", help="Play the top result, skipping the picker"),
+):
+    """Resume playback, or search for a song and play it."""
+    if song is None:
+        _api("PUT", "/me/player/play")
+        log.info("▶ play")
+        return
+    items = _search(song, "track")
+    if not items:
+        log.info("No results for %r.", song)
+        return
+    if first:
+        _play_item(items[0], "track")
+        return
+    chosen = _pick(items, "track")
+    if chosen:
+        _play_item(chosen, "track")
+    else:
+        log.info("Cancelled.")
+
+
+@app.command()
+def pause():
+    """Pause playback."""
+    _api("PUT", "/me/player/pause")
+    log.info("⏸ pause")
+
+
+@app.command()
+def playpause():
+    """Toggle play/pause based on the current state."""
+    data = _api("GET", "/me/player") or {}
+    if data.get("is_playing"):
+        _api("PUT", "/me/player/pause")
+        log.info("⏸ pause")
+    else:
+        _api("PUT", "/me/player/play")
+        log.info("▶ play")
+
+
+@app.command(name="pp")
+def pp():
+    """Alias for `playpause`."""
+    playpause()
+
+
+@app.command()
+def next():
+    """Skip to the next track."""
+    _api("POST", "/me/player/next")
+    log.info("⏭ next")
+
+
+@app.command(name="prev")
+def prev():
+    """Go to the previous track."""
+    _api("POST", "/me/player/previous")
+    log.info("⏮ previous")
+
+
+@app.command()
+def vol(
+    level: int = typer.Argument(..., help="Volume 0–100"),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip the large-jump confirmation"),
+):
+    """Set the volume (0–100). Confirms before a jump up of 50 or more."""
+    level = max(0, min(100, level))
+    # Guardrail: a large positive jump can be a painful surprise — confirm first.
+    if not yes:
+        current = (_api("GET", "/me/player") or {}).get("device", {}).get("volume_percent")
+        if current is not None and level - current >= 50:
+            if not typer.confirm(
+                f"Raise volume from {current}% to {level}% (+{level - current})?"
+            ):
+                log.info("Volume unchanged.")
+                raise typer.Abort()
+    _api("PUT", "/me/player/volume", params={"volume_percent": level})
+    log.info("🔊 volume %d%%", level)
+
+
+@app.command()
+def shuffle(state: str = typer.Argument(..., help="on | off")):
+    """Turn shuffle on or off."""
+    s = state.lower()
+    if s not in ("on", "off"):
+        raise typer.BadParameter("state must be 'on' or 'off'")
+    _api("PUT", "/me/player/shuffle", params={"state": "true" if s == "on" else "false"})
+    log.info("🔀 shuffle %s", s)
+
+
+@app.command()
+def repeat(mode: str = typer.Argument(..., help="track | context | off")):
+    """Set repeat mode (track, context, or off)."""
+    m = mode.lower()
+    if m not in ("track", "context", "off"):
+        raise typer.BadParameter("mode must be 'track', 'context', or 'off'")
+    _api("PUT", "/me/player/repeat", params={"state": m})
+    log.info("🔁 repeat %s", m)
+
+
+@app.command()
+def devices():
+    """List your available Spotify devices."""
+    data = _api("GET", "/me/player/devices") or {}
+    items = data.get("devices", [])
+    if not items:
+        log.info("No devices found. Open Spotify on a device first.")
+        return
+    for d in items:
+        marker = "●" if d.get("is_active") else "○"
+        vol = d.get("volume_percent")
+        vol_str = f"  {vol}%" if vol is not None else ""
+        typer.echo(f"{marker} {d['name']}  [{d.get('type', '?')}]{vol_str}")
+
+
+@app.command()
+def transfer(name: str = typer.Argument(..., help="Device name (fuzzy matched)")):
+    """Transfer playback to a device by name."""
+    device_id = _resolve_device(name)
+    _api("PUT", "/me/player", json={"device_ids": [device_id], "play": True})
+    log.info("➡ transferred playback to %r", name)
+
+
+@app.command()
+def search(
+    query: str = typer.Argument(..., help="Search query"),
+    play: bool = typer.Option(False, "--play", help="Pick a result to play"),
+    type_: str = typer.Option("track", "--type", help="track | album | artist | playlist"),
+):
+    """Search the Spotify catalog. With --play, pick a result to play."""
+    items = _search(query, type_)
+    if not items:
+        log.info("No results for %r.", query)
+        return
+    if not play:
+        _print_results(items, type_)
+        return
+    chosen = _pick(items, type_)
+    if chosen:
+        _play_item(chosen, type_)
+    else:
+        log.info("Cancelled.")
+
+
+def _extract_playlist_id(value: str) -> str:
+    """Accept a Spotify URI, URL, or raw ID and return just the playlist ID."""
+    # spotify:playlist:<id>
+    if value.startswith("spotify:playlist:"):
+        return value.split(":")[-1]
+    # https://open.spotify.com/playlist/<id>?...
+    if "open.spotify.com/playlist/" in value:
+        return value.split("/playlist/")[-1].split("?")[0]
+    # Assume raw ID
+    return value.strip()
+
+
+def _fetch_all_playlist_tracks(playlist_id: str) -> list[dict]:
+    """Fetch every track in a playlist, handling Spotify's 100-item page limit."""
+    tracks = []
+    url = f"/playlists/{playlist_id}/tracks"
+    params = {"limit": 100, "offset": 0, "fields": (
+        "next,items(added_at,track(id,name,uri,duration_ms,popularity,explicit,"
+        "artists(id,name),album(id,name,release_date),"
+        "external_urls))"
+    )}
+    while url:
+        page = _api("GET", url, params=params) or {}
+        for item in page.get("items", []):
+            t = item.get("track")
+            if not t or t.get("id") is None:  # skip local/null tracks
+                continue
+            tracks.append({
+                "added_at": item.get("added_at"),
+                "id": t["id"],
+                "name": t.get("name"),
+                "uri": t.get("uri"),
+                "duration_ms": t.get("duration_ms"),
+                "popularity": t.get("popularity"),
+                "explicit": t.get("explicit"),
+                "artists": [{"id": a["id"], "name": a["name"]} for a in t.get("artists", [])],
+                "album": {
+                    "id": t["album"]["id"],
+                    "name": t["album"]["name"],
+                    "release_date": t["album"].get("release_date"),
+                } if t.get("album") else None,
+                "url": (t.get("external_urls") or {}).get("spotify"),
+            })
+        url = page.get("next")
+        params = {}  # next URL already contains all query params
+    return tracks
+
+
+_AF_FIELDS = (
+    "tempo", "energy", "danceability", "valence", "loudness",
+    "acousticness", "instrumentalness", "liveness", "speechiness",
+    "key", "mode", "time_signature",
+)
+
+
+def _fetch_audio_features(track_ids: list[str]) -> dict:
+    """Return {track_id: {tempo, energy, …}} for the given IDs (batched).
+
+    Uses requests directly (not _api) so a 403 is a soft warning, not a hard exit.
+    Spotify restricted this endpoint in Nov 2024 for most app tiers.
+    """
+    out: dict = {}
+    token = _get_access_token()
+    for i in range(0, len(track_ids), 100):
+        batch = track_ids[i : i + 100]
+        resp = requests.get(
+            f"{API_BASE}/audio-features",
+            headers={"Authorization": f"Bearer {token}"},
+            params={"ids": ",".join(batch)},
+            timeout=15,
+        )
+        if resp.status_code == 403:
+            log.warning(
+                "Audio features unavailable (403) — Spotify restricted this endpoint "
+                "in Nov 2024 for most app tiers. BPM/energy data will be skipped."
+            )
+            break
+        if resp.status_code != 200:
+            log.warning("Audio features request failed (%s); skipping.", resp.status_code)
+            break
+        for af in resp.json().get("audio_features") or []:
+            if af and af.get("id"):
+                out[af["id"]] = {k: af.get(k) for k in _AF_FIELDS}
+    return out
+
+
+@app.command(name="playlist-export")
+def playlist_export(
+    query: str = typer.Argument(..., help="Playlist name/search query, Spotify URI, or URL"),
+    output: Optional[Path] = typer.Option(None, "--output", "-o", help="Output JSON file (default: <playlist>.json)"),
+    audio_features: bool = typer.Option(True, "--audio-features/--no-audio-features", help="Embed BPM and audio features into each track"),
+):
+    """Export all tracks from a playlist to a JSON file for analysis."""
+    # Resolve to a playlist ID — either directly or via search.
+    is_direct = (
+        query.startswith("spotify:playlist:")
+        or "open.spotify.com/playlist/" in query
+        or re.fullmatch(r"[A-Za-z0-9]{22}", query)
+    )
+
+    if is_direct:
+        playlist_id = _extract_playlist_id(query)
+        meta = _api("GET", f"/playlists/{playlist_id}", params={
+            "fields": "id,name,description,owner(display_name),snapshot_id,tracks(total)"
+        }) or {}
+        playlist_name = meta.get("name", playlist_id)
+    else:
+        results = _search(query, "playlist", limit=10)
+        if not results:
+            log.error("No playlists found for %r.", query)
+            raise typer.Exit(code=1)
+        chosen = _pick(results, "playlist")
+        if not chosen:
+            log.info("Cancelled.")
+            return
+        playlist_id = chosen["id"]
+        meta = chosen
+
+    playlist_name = meta.get("name", playlist_id)
+    total = (meta.get("tracks") or {}).get("total") if isinstance(meta.get("tracks"), dict) else meta.get("tracks", {}).get("total", "?")
+    owner = (meta.get("owner") or {}).get("display_name", "?")
+
+    typer.echo(f"Exporting: {playlist_name}  ({total} tracks)  by {owner}")
+
+    tracks = _fetch_all_playlist_tracks(playlist_id)
+
+    if audio_features:
+        typer.echo("Fetching audio features (BPM, energy, key, …)…")
+        ids = [t["id"] for t in tracks if t.get("id")]
+        af_map = _fetch_audio_features(ids)
+        for t in tracks:
+            t["features"] = af_map.get(t["id"])
+        if not af_map:
+            typer.echo("  Audio features unavailable — exporting without BPM/energy data.")
+
+    payload = {
+        "playlist": {
+            "id": meta.get("id", playlist_id),
+            "name": playlist_name,
+            "description": meta.get("description", ""),
+            "owner": owner,
+            "total": len(tracks),
+            "snapshot_id": meta.get("snapshot_id"),
+        },
+        "tracks": tracks,
+    }
+
+    if output is None:
+        safe_name = re.sub(r'[^\w\- ]', '', playlist_name).strip().replace(" ", "_")
+        output = Path(f"{safe_name}.json")
+
+    output.write_text(json.dumps(payload, indent=2, ensure_ascii=False))
+    typer.echo(f"Saved {len(tracks)} tracks → {output}")
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# BPM enrichment via GetSongBPM  (https://getsongbpm.com/api)
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _bpm_cache_load() -> dict:
+    """Load the shared BPM cache (keyed by 'artist|title')."""
+    if BPM_CACHE_FILE.exists():
+        try:
+            return json.loads(BPM_CACHE_FILE.read_text())
+        except (json.JSONDecodeError, OSError):
+            pass
+    return {}
+
+
+def _bpm_cache_save(cache: dict) -> None:
+    BPM_CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    BPM_CACHE_FILE.write_text(json.dumps(cache, indent=2, ensure_ascii=False))
+
+
+def _bpm_cache_key(artist: str, title: str) -> str:
+    return f"{artist.lower().strip()}|{title.lower().strip()}"
+
+
+def _getsongbpm_key(explicit: Optional[str] = None) -> str:
+    key = explicit or os.environ.get("GETSONGBPM_API_KEY") or _load_config().get("getsongbpm_api_key")
+    if not key:
+        raise typer.BadParameter(
+            "No GetSongBPM API key. Register (free) at https://getsongbpm.com/api "
+            "then pass --api-key or set GETSONGBPM_API_KEY."
+        )
+    return key
+
+
+def _bpm_lookup(api_key: str, artist: str, title: str) -> Optional[float]:
+    """Search GetSongBPM for a single track and return its BPM, or None."""
+    lookup = f"song:{urllib.parse.quote(title)}+artist:{urllib.parse.quote(artist)}"
+    try:
+        resp = requests.get(
+            f"{GETSONGBPM_API}/search/",
+            params={"api_key": api_key, "type": "both", "lookup": lookup},
+            timeout=10,
+        )
+    except requests.RequestException:
+        return None
+
+    if resp.status_code != 200:
+        return None
+
+    results = resp.json().get("search") or []
+    if not results:
+        return None
+
+    # Pick the best match: prefer results where both title and artist match closely.
+    title_lc = title.lower()
+    artist_lc = artist.lower()
+    for r in results[:5]:
+        r_title = (r.get("title") or "").lower()
+        r_artist = (r.get("artist") or {}).get("name", "").lower()
+        title_ok = title_lc in r_title or r_title in title_lc
+        artist_ok = artist_lc in r_artist or r_artist in artist_lc
+        if title_ok and artist_ok:
+            try:
+                return float(r["tempo"])
+            except (KeyError, ValueError, TypeError):
+                pass
+
+    # Looser fallback: title-only match
+    for r in results[:3]:
+        r_title = (r.get("title") or "").lower()
+        if title_lc in r_title or r_title in title_lc:
+            try:
+                return float(r["tempo"])
+            except (KeyError, ValueError, TypeError):
+                pass
+
+    return None
+
+
+@app.command(name="enrich-bpm")
+def enrich_bpm(
+    playlist_file: Path = typer.Argument(..., help="Exported playlist JSON to enrich"),
+    api_key: Optional[str] = typer.Option(None, "--api-key", "-k", help="GetSongBPM API key (or GETSONGBPM_API_KEY env var)"),
+    output: Optional[Path] = typer.Option(None, "--output", "-o", help="Output file (default: overwrites input)"),
+    force: bool = typer.Option(False, "--force", "-f", help="Re-fetch even tracks that already have BPM"),
+    delay: float = typer.Option(0.25, "--delay", help="Seconds between API calls (be kind to the free tier)"),
+):
+    """Fetch BPM for each track from GetSongBPM and patch the playlist JSON.
+
+    Requires a free API key from https://getsongbpm.com/api
+    (only needs an email; a GitHub repo URL is accepted as the website).
+    """
+    key = _getsongbpm_key(api_key)
+
+    # Persist the key for future calls
+    if api_key:
+        cfg = _load_config()
+        cfg["getsongbpm_api_key"] = api_key
+        _save_config(cfg)
+
+    try:
+        data = json.loads(playlist_file.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        log.error("Could not read %s: %s", playlist_file, exc)
+        raise typer.Exit(code=1)
+
+    tracks = data.get("tracks", [])
+    pl_name = data.get("playlist", {}).get("name", playlist_file.stem)
+
+    todo = [t for t in tracks if force or t.get("bpm") is None]
+    if not todo:
+        typer.echo(f"All {len(tracks)} tracks already have BPM. Use --force to re-fetch.")
+        return
+
+    bpm_cache = _bpm_cache_load()
+    cache_hits = sum(
+        1 for t in todo
+        if _bpm_cache_key(((t.get("artists") or [{}])[0]).get("name", ""), t.get("name", "")) in bpm_cache
+    )
+    typer.echo(
+        f"Enriching {len(todo)}/{len(tracks)} tracks from '{pl_name}' "
+        f"({cache_hits} cached, {len(todo) - cache_hits} to fetch)…"
+    )
+
+    found = skipped = fetched = 0
+    pad = len(str(len(todo)))
+    cache_dirty = False
+
+    for i, track in enumerate(todo, 1):
+        artist = ((track.get("artists") or [{}])[0]).get("name", "")
+        title = track.get("name", "")
+        ck = _bpm_cache_key(artist, title)
+
+        if ck in bpm_cache:
+            entry = bpm_cache[ck]
+            bpm = entry.get("bpm")
+            source = entry.get("source", "getsongbpm")
+            from_cache = True
+        else:
+            bpm = _bpm_lookup(key, artist, title)
+            source = "getsongbpm" if bpm else None
+            bpm_cache[ck] = {"bpm": bpm, "source": source, "artist": artist, "title": title}
+            cache_dirty = True
+            from_cache = False
+            fetched += 1
+            if i < len(todo):
+                time.sleep(delay)
+
+        track["bpm"] = bpm
+        track["bpm_source"] = source
+
+        marker = f"{bpm:.0f} BPM" if bpm else "—"
+        tag = " (cached)" if from_cache else ""
+        typer.echo(f"  [{i:>{pad}}/{len(todo)}] {artist} — {title}: {marker}{tag}")
+
+        if bpm:
+            found += 1
+        else:
+            skipped += 1
+
+    if cache_dirty:
+        _bpm_cache_save(bpm_cache)
+        typer.echo(f"  BPM cache updated → {BPM_CACHE_FILE}  ({len(bpm_cache)} entries)")
+
+    out = output or playlist_file
+    out.write_text(json.dumps(data, indent=2, ensure_ascii=False))
+    typer.echo(f"\nFound {found}/{len(todo)} BPMs → {out}")
+    if skipped:
+        typer.echo(f"  {skipped} tracks not matched on GetSongBPM.")
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Dashboard UI  (React/Vite build served as static files)
+# ──────────────────────────────────────────────────────────────────────────
+
+_UI_DIR = Path(__file__).parent.parent / "spoti-ui"
+
+_PLACEHOLDER_HTML = """\
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Spoti Dashboard</title>
+<script src="https://cdn.jsdelivr.net/npm/plotly.js-dist-min@2/plotly.min.js"></script>
+<style>
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+:root{
+  --bg:#0d0d0d;--surface:#1a1a1a;--surface2:#252525;
+  --green:#1db954;--text:#e4e4e4;--muted:#666;--radius:10px;
+}
+body{background:var(--bg);color:var(--text);font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;min-height:100vh}
+header{background:#000;padding:14px 28px;display:flex;align-items:center;gap:10px;border-bottom:1px solid #1a1a1a}
+header h1{color:var(--green);font-size:1.05rem;letter-spacing:-.01em;font-weight:700}
+header small{color:var(--muted);font-size:.78rem}
+.tabs{background:var(--surface);display:flex;padding:0 24px;border-bottom:1px solid #222}
+.tab{padding:11px 18px;cursor:pointer;font-size:.86rem;color:var(--muted);border-bottom:2px solid transparent;user-select:none;transition:color .12s,border-color .12s}
+.tab.active{color:var(--text);border-color:var(--green)}
+.tab:hover:not(.active){color:var(--text)}
+.pane{display:none;padding:28px;max-width:1100px;margin:0 auto}
+.pane.active{display:block}
+
+/* Library */
+.grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(200px,1fr));gap:14px}
+.card{background:var(--surface);border-radius:var(--radius);padding:18px;border:2px solid transparent;transition:border-color .12s,background .12s;display:flex;flex-direction:column}
+.card:hover{background:var(--surface2)}
+.card.sel{border-color:var(--green)}
+.card-name{font-weight:600;font-size:.9rem;margin-bottom:5px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.card-sub{font-size:.76rem;color:var(--muted);flex:1}
+.btn{margin-top:14px;background:var(--green);color:#000;border:none;border-radius:20px;padding:7px 0;font-size:.78rem;font-weight:700;cursor:pointer;width:100%;transition:background .1s}
+.btn:hover{background:#1ed760}
+
+/* Analysis */
+.anlys-head{margin-bottom:22px}
+.anlys-head h2{font-size:1.05rem;margin-bottom:4px}
+.anlys-head p{color:var(--muted);font-size:.82rem}
+.chart-stack{display:flex;flex-direction:column;gap:18px}
+.chart-box{background:var(--surface);border-radius:var(--radius);padding:20px 18px}
+.chart-box h3{font-size:.7rem;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--muted);margin-bottom:14px}
+.chart-box h3 em{color:var(--green);font-style:normal}
+
+.ph{color:var(--muted);padding:60px;text-align:center;font-size:.9rem;line-height:1.6}
+.ph code{background:var(--surface);padding:2px 7px;border-radius:4px;font-size:.82rem;color:var(--text)}
+</style>
+</head>
+<body>
+<header>
+  <h1>&#9899; Spoti</h1>
+  <small>Dashboard</small>
+</header>
+<div class="tabs">
+  <div class="tab active" data-tab="library">Library</div>
+  <div class="tab" data-tab="analysis">Analysis</div>
+</div>
+<div class="pane active" id="pane-library">
+  <div id="lib" class="ph">Loading&hellip;</div>
+</div>
+<div class="pane" id="pane-analysis">
+  <div id="anlys" class="ph">&#8592; Pick a playlist in the Library tab.</div>
+</div>
+
+<script>
+function esc(s){return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;')}
+
+const GREEN='#1db954';
+const BASE={paper_bgcolor:'#1a1a1a',plot_bgcolor:'#1a1a1a',
+  font:{color:'#e4e4e4',family:'-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif',size:12},
+  xaxis:{gridcolor:'#2b2b2b',zerolinecolor:'#2b2b2b'},
+  yaxis:{gridcolor:'#2b2b2b',zerolinecolor:'#2b2b2b'}};
+const CFG={responsive:true,displayModeBar:false};
+
+// ── tabs ──────────────────────────────────────────────────────────────────
+document.querySelectorAll('.tab').forEach(tab=>{
+  tab.addEventListener('click',()=>{
+    document.querySelectorAll('.tab').forEach(t=>t.classList.toggle('active',t===tab));
+    document.querySelectorAll('.pane').forEach(p=>p.classList.toggle('active',p.id==='pane-'+tab.dataset.tab));
+    if(tab.dataset.tab==='analysis')
+      document.querySelectorAll('[id^="ch-"]').forEach(el=>Plotly.Plots.resize(el));
+  });
+});
+
+// ── library ───────────────────────────────────────────────────────────────
+async function loadLib(){
+  const playlists=await fetch('/api/playlists').then(r=>r.json());
+  const el=document.getElementById('lib');
+  if(!playlists.length){
+    el.innerHTML='<div class="ph">No exported playlists found.<br>Run <code>spoti playlist-export &ldquo;my playlist&rdquo;</code> first.</div>';
+    return;
+  }
+  el.className='grid';
+  el.innerHTML=playlists.map(p=>`
+    <div class="card" data-file="${esc(p.file)}">
+      <div class="card-name" title="${esc(p.name)}">${esc(p.name)}</div>
+      <div class="card-sub">${p.total} tracks &middot; ${esc(p.owner)}</div>
+      <button class="btn">Analyse &rarr;</button>
+    </div>`).join('');
+  el.querySelectorAll('.btn').forEach(btn=>{
+    btn.addEventListener('click',()=>analyse(btn.closest('.card').dataset.file));
+  });
+}
+
+// ── analysis ──────────────────────────────────────────────────────────────
+async function analyse(file){
+  document.querySelectorAll('.tab').forEach(t=>t.classList.toggle('active',t.dataset.tab==='analysis'));
+  document.querySelectorAll('.pane').forEach(p=>p.classList.toggle('active',p.id==='pane-analysis'));
+  document.querySelectorAll('.card').forEach(c=>c.classList.toggle('sel',c.dataset.file===file));
+
+  const el=document.getElementById('anlys');
+  el.className='ph'; el.textContent='Fetching audio features…';
+
+  const [playlist,features]=await Promise.all([
+    fetch('/api/playlist?file='+encodeURIComponent(file)).then(r=>r.json()),
+    fetch('/api/audio-features?file='+encodeURIComponent(file)).then(r=>r.json()),
+  ]);
+  render(playlist,features,el);
+}
+
+function render(playlist,features,el){
+  const tracks=playlist.tracks||[];
+  const pl=playlist.playlist||{};
+
+  // artist counts
+  const ac={};
+  tracks.forEach(t=>(t.artists||[]).forEach(a=>{ac[a.name]=(ac[a.name]||0)+1}));
+  const sorted=Object.entries(ac).sort((a,b)=>b[1]-a[1]).slice(0,25);
+  const aNames=sorted.map(([n])=>n).reverse();
+  const aCounts=sorted.map(([,c])=>c).reverse();
+
+  // bpm series
+  const bpmX=[],bpmY=[],bpmTip=[];
+  tracks.forEach((t,i)=>{
+    const af=features[t.id];
+    if(!af||!af.tempo)return;
+    bpmX.push(i+1);
+    bpmY.push(+af.tempo.toFixed(1));
+    bpmTip.push('#'+(i+1)+' – '+t.name+'<br>'+(t.artists||[]).map(a=>a.name).join(', '));
+  });
+  const hasBpm=bpmX.length>0;
+
+  el.className='';
+  el.innerHTML=`
+    <div class="anlys-head">
+      <h2>${esc(pl.name||'')}</h2>
+      <p>${pl.total||0} tracks &middot; ${esc(pl.owner||'')}</p>
+    </div>
+    <div class="chart-stack">
+      <div class="chart-box"><h3>Artist distribution <em>(top 25)</em></h3><div id="ch-artists"></div></div>
+      <div class="chart-box"><h3>BPM distribution</h3><div id="ch-bpm-hist"></div></div>
+      <div class="chart-box"><h3>BPM over playlist</h3><div id="ch-bpm-line"></div></div>
+    </div>`;
+
+  const artistH=Math.max(260,aNames.length*22+60);
+  Plotly.newPlot('ch-artists',[{
+    type:'bar',orientation:'h',x:aCounts,y:aNames,
+    marker:{color:GREEN},
+    hovertemplate:'<b>%{y}</b>: %{x} tracks<extra></extra>',
+  }],{...BASE,height:artistH,
+    margin:{l:160,r:20,t:8,b:40},
+    xaxis:{...BASE.xaxis,title:'Tracks',tickformat:'d'},
+  },CFG);
+
+  Plotly.newPlot('ch-bpm-hist',[{
+    type:'histogram',x:bpmY,nbinsx:20,
+    marker:{color:GREEN,line:{color:'#0d0d0d',width:1}},
+    hovertemplate:'BPM ~%{x}: %{y} tracks<extra></extra>',
+  }],{...BASE,height:260,
+    margin:{l:60,r:20,t:8,b:48},
+    xaxis:{...BASE.xaxis,title:'BPM'},
+    yaxis:{...BASE.yaxis,title:'Tracks'},
+  },CFG);
+
+  Plotly.newPlot('ch-bpm-line',
+    hasBpm?[{
+      type:'scatter',mode:'lines+markers',
+      x:bpmX,y:bpmY,text:bpmTip,
+      hovertemplate:'%{text}<br><b>BPM: %{y}</b><extra></extra>',
+      line:{color:GREEN,width:1.5},
+      marker:{color:GREEN,size:5},
+    }]:[],
+    {...BASE,height:300,
+      margin:{l:60,r:20,t:8,b:48},
+      xaxis:{...BASE.xaxis,title:'Track position'},
+      yaxis:{...BASE.yaxis,title:'BPM'},
+      ...(hasBpm?{}:{annotations:[{
+        text:'No BPM data — run <b>spoti login</b> to refresh scopes',
+        xref:'paper',yref:'paper',x:.5,y:.5,showarrow:false,
+        font:{color:'#666',size:13},
+      }]}),
+    },CFG);
+}
+
+loadLib();
+</script>
+</body>
+</html>"""
+
+
+def _make_ui_handler(search_dir: Path, dist_dir: Optional[Path]):
+    import mimetypes
+
+    class _Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802
+            try:
+                self._route()
+            except Exception as exc:
+                self._json({"error": str(exc)}, code=500)
+
+        def _route(self):
+            parsed = urllib.parse.urlparse(self.path)
+            qs = urllib.parse.parse_qs(parsed.query)
+            p = parsed.path
+
+            if p == "/api/playlists":
+                self._json(self._list_playlists())
+            elif p == "/api/playlist":
+                self._json(self._get_playlist(qs.get("file", [None])[0]))
+            elif p == "/api/audio-features":
+                self._json(self._get_audio_features(qs.get("file", [None])[0]))
+            elif dist_dir is not None:
+                self._serve_static(p)
+            else:
+                # --dev mode: no static files, just the API
+                self.send_response(404)
+                self.end_headers()
+
+        def _serve_static(self, path: str):
+            rel = path.lstrip("/") or "index.html"
+            target = dist_dir / rel
+            # SPA fallback: unknown paths → index.html
+            if not target.exists() or target.is_dir():
+                target = dist_dir / "index.html"
+            try:
+                content = target.read_bytes()
+                mime, _ = mimetypes.guess_type(str(target))
+                self.send_response(200)
+                self.send_header("Content-Type", mime or "application/octet-stream")
+                self.send_header("Content-Length", len(content))
+                self.end_headers()
+                self.wfile.write(content)
+            except OSError:
+                self.send_response(404)
+                self.end_headers()
+
+        def _json(self, data, code=200):
+            body = json.dumps(data, ensure_ascii=False).encode()
+            self.send_response(code)
+            self.send_header("Content-Type", "application/json; charset=utf-8")
+            self.send_header("Content-Length", len(body))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def _list_playlists(self):
+            result = []
+            for p in sorted(search_dir.glob("*.json")):
+                if p.name.startswith("."):
+                    continue
+                try:
+                    data = json.loads(p.read_text())
+                    pl = data.get("playlist", {})
+                    result.append({
+                        "file": p.name,
+                        "name": pl.get("name", p.stem),
+                        "total": pl.get("total", 0),
+                        "owner": pl.get("owner", "?"),
+                    })
+                except (json.JSONDecodeError, OSError):
+                    pass
+            return result
+
+        def _get_playlist(self, filename):
+            if not filename:
+                return {"error": "no file specified"}
+            try:
+                return json.loads((search_dir / filename).read_text())
+            except (OSError, json.JSONDecodeError) as exc:
+                return {"error": str(exc)}
+
+        def _get_audio_features(self, filename):
+            if not filename:
+                return {}
+            cache = search_dir / ("." + filename + ".af.json")
+            playlist_path = search_dir / filename
+            try:
+                playlist = json.loads(playlist_path.read_text())
+            except (OSError, json.JSONDecodeError):
+                return {}
+
+            tracks = playlist.get("tracks", [])
+
+            # If the export already has embedded features, use them directly.
+            if tracks and tracks[0].get("features") is not None:
+                return {t["id"]: t["features"] for t in tracks if t.get("id") and t.get("features")}
+
+            track_ids = [t["id"] for t in tracks if t.get("id")]
+            if not track_ids:
+                return {}
+
+            stored: dict = {}
+            if cache.exists():
+                try:
+                    stored = json.loads(cache.read_text())
+                except (json.JSONDecodeError, OSError):
+                    pass
+
+            missing = [tid for tid in track_ids if tid not in stored]
+            if missing:
+                try:
+                    fetched = _fetch_audio_features(missing)
+                    stored.update(fetched)
+                except Exception:
+                    pass
+                try:
+                    cache.write_text(json.dumps(stored, indent=2))
+                except OSError:
+                    pass
+
+            return stored
+
+        def log_message(self, *args):
+            pass
+
+    return _Handler
+
+
+@app.command()
+def ui(
+    directory: Optional[Path] = typer.Option(None, "--dir", "-d", help="Directory with exported playlist JSONs (default: cwd)"),
+    port: int = typer.Option(8889, "--port", "-p", help="Local server port"),
+    dev: bool = typer.Option(False, "--dev", help="API-only mode for use alongside `npm run dev`"),
+):
+    """Launch the Spoti Dashboard (React UI + local API server).
+
+    First build the UI:  cd python/danfault/spoti-ui && npm i && npm run build
+    Dev workflow:        spoti ui --dev  +  npm run dev (in spoti-ui/)
+    """
+    search_dir = (directory or Path.cwd()).resolve()
+    if not search_dir.is_dir():
+        log.error("Directory not found: %s", search_dir)
+        raise typer.Exit(code=1)
+
+    dist_dir = (_UI_DIR / "dist") if not dev else None
+
+    if not dev and not dist_dir.exists():
+        log.error("UI not built. Run:")
+        log.error("  cd %s", _UI_DIR)
+        log.error("  npm install && npm run build")
+        raise typer.Exit(code=1)
+
+    url = f"http://127.0.0.1:{port}"
+    server = http.server.HTTPServer(("127.0.0.1", port), _make_ui_handler(search_dir, dist_dir))
+
+    if dev:
+        log.info("API server at %s  (Ctrl-C to stop)", url)
+        log.info("Start the frontend:  npm run dev --prefix %s", _UI_DIR)
+    else:
+        log.info("Spoti Dashboard → %s  (Ctrl-C to stop)", url)
+        log.info("Serving playlists from %s", search_dir)
+        threading.Thread(target=lambda: (time.sleep(0.4), webbrowser.open(url)), daemon=True).start()
+
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        log.info("Stopped.")
+
+
+if __name__ == "__main__":
+    app()

--- a/python/danfault/danfault/vault.py
+++ b/python/danfault/danfault/vault.py
@@ -1,0 +1,126 @@
+"""Resolve vault and repo locations from a machine-local config file.
+
+Skills and other tools reference logical names (a vault, a work repo) instead of
+hardcoding personal paths. The real paths live in a per-machine config that is
+**never committed**:
+
+    ~/.config/danfault/vault.yaml   (or $XDG_CONFIG_HOME/danfault/vault.yaml)
+
+Schema::
+
+    default_vault: main
+    vaults:
+      main:
+        path: ~/path/to/vault
+        domains: [domain-a, domain-b, personal]
+    repos:
+      my-repo: { path: ~/path/to/repo, github: owner/my-repo }
+
+CLI::
+
+    danfault vault path [--vault NAME]        # absolute path to a vault
+    danfault vault domains [--vault NAME]     # allowed note domains, one per line
+    danfault vault repos [--github]           # every repo's path (or owner/repo)
+    danfault vault repo NAME [--github]       # one repo's path (or owner/repo)
+"""
+
+import os
+from pathlib import Path
+from typing import Optional
+
+import typer
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - surfaced as a friendly error at runtime
+    yaml = None
+
+app = typer.Typer(help="Resolve vault/repo locations from ~/.config/danfault/vault.yaml")
+
+
+def _config_path() -> Path:
+    base = os.environ.get("XDG_CONFIG_HOME") or os.path.expanduser("~/.config")
+    return Path(base) / "danfault" / "vault.yaml"
+
+
+def _load() -> dict:
+    if yaml is None:
+        typer.secho("PyYAML is not installed. Run: pip install pyyaml", fg="red", err=True)
+        raise typer.Exit(1)
+    path = _config_path()
+    if not path.exists():
+        typer.secho(f"Config not found: {path}", fg="red", err=True)
+        typer.secho("Create it — see `danfault vault --help` for the schema.", err=True)
+        raise typer.Exit(1)
+    data = yaml.safe_load(path.read_text()) or {}
+    if not isinstance(data, dict):
+        typer.secho(f"Malformed config (expected a mapping): {path}", fg="red", err=True)
+        raise typer.Exit(1)
+    return data
+
+
+def _expand(p: str) -> str:
+    return os.path.expanduser(str(p))
+
+
+def _resolve_vault(cfg: dict, name: Optional[str]) -> tuple[str, dict]:
+    vaults = cfg.get("vaults") or {}
+    name = name or cfg.get("default_vault")
+    if not name:
+        typer.secho("No vault specified and no default_vault in config.", fg="red", err=True)
+        raise typer.Exit(1)
+    if name not in vaults:
+        typer.secho(f"Unknown vault '{name}'. Known: {', '.join(vaults) or '(none)'}", fg="red", err=True)
+        raise typer.Exit(1)
+    return name, vaults[name] or {}
+
+
+@app.command()
+def path(vault: Optional[str] = typer.Option(None, "--vault", help="Vault name (default: default_vault)")):
+    """Print the absolute path to a vault."""
+    cfg = _load()
+    _, v = _resolve_vault(cfg, vault)
+    if not v.get("path"):
+        typer.secho("Vault has no 'path' set.", fg="red", err=True)
+        raise typer.Exit(1)
+    typer.echo(_expand(v["path"]))
+
+
+@app.command()
+def domains(vault: Optional[str] = typer.Option(None, "--vault", help="Vault name (default: default_vault)")):
+    """Print a vault's declared domains, one per line."""
+    cfg = _load()
+    _, v = _resolve_vault(cfg, vault)
+    for d in v.get("domains") or []:
+        typer.echo(d)
+
+
+@app.command()
+def repos(github: bool = typer.Option(False, "--github", help="Print owner/repo slugs instead of paths")):
+    """Print every configured repo (path, or slug with --github), one per line."""
+    cfg = _load()
+    for name, meta in (cfg.get("repos") or {}).items():
+        meta = meta or {}
+        value = meta.get("github") if github else meta.get("path")
+        if value:
+            typer.echo(value if github else _expand(value))
+
+
+@app.command()
+def repo(
+    name: str = typer.Argument(..., help="Repo name as declared in config"),
+    github: bool = typer.Option(False, "--github", help="Print the owner/repo slug instead of the path"),
+):
+    """Print one repo's path (or its owner/repo slug with --github)."""
+    cfg = _load()
+    repos_cfg = cfg.get("repos") or {}
+    if name not in repos_cfg:
+        typer.secho(f"Unknown repo '{name}'. Known: {', '.join(repos_cfg) or '(none)'}", fg="red", err=True)
+        raise typer.Exit(1)
+    meta = repos_cfg[name] or {}
+    value = meta.get("github") if github else meta.get("path")
+    if not value:
+        field = "github" if github else "path"
+        typer.secho(f"Repo '{name}' has no '{field}' set.", fg="red", err=True)
+        raise typer.Exit(1)
+    typer.echo(value if github else _expand(value))

--- a/python/danfault/pyproject.toml
+++ b/python/danfault/pyproject.toml
@@ -17,7 +17,10 @@ classifiers = [
 dependencies = [
     "termcolor",
     "tqdm",
-    "numpy"
+    "numpy",
+    "requests",
+    "questionary",
+    "pyyaml"
 ]
 [project.urls]
 "Homepage" = "https://github.com/dancps/danfault"
@@ -63,6 +66,7 @@ danfault = "danfault"
 danfault = "danfault.main:app"
 rmatlab = "danfault.matlab:main"
 coffee = "danfault.coffee:main"
+spoti = "danfault.spotify:app"
 
 [tool.pytest.ini_options]
 addopts = "--cov=mleng --cov-report xml --cov-report term-missing"# --cov-fail-under 95"

--- a/python/danfault/spoti-ui/.npmrc
+++ b/python/danfault/spoti-ui/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/

--- a/python/danfault/spoti-ui/index.html
+++ b/python/danfault/spoti-ui/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Spoti Dashboard</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/python/danfault/spoti-ui/package-lock.json
+++ b/python/danfault/spoti-ui/package-lock.json
@@ -1,0 +1,3036 @@
+{
+  "name": "spoti-ui",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "spoti-ui",
+      "version": "0.0.1",
+      "dependencies": {
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "recharts": "^2.12.7"
+      },
+      "devDependencies": {
+        "@vitejs/plugin-react": "^4.3.1",
+        "autoprefixer": "^10.4.19",
+        "postcss": "^8.4.38",
+        "tailwindcss": "^3.4.4",
+        "vite": "^5.3.1"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.0.tgz",
+      "integrity": "sha512-IPIQ55ythEHkfEd9jMEi32OQ7SxURsGA43JI22lj01OLZNt2NUbJX8YUHxkVWyQ6daHPNn0truF5nSj3DQp6YQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.0.tgz",
+      "integrity": "sha512-M6s9cr10MibETyo8JsOkq+Lo1+lU6hcvb1MApnUql5qte/5hMEgzlN8/ReIKNfRV8rrqX50W1BX9zoUhC192RA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.0.tgz",
+      "integrity": "sha512-BqCoMoIbn0keKys+dEAdBa70EtOwV1bEsQCUgU9FdiZmmMge/Zk7LlkYGqbrdHR+Frnt0E1FOanly+rlwvvQzw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.0.tgz",
+      "integrity": "sha512-SIMzST3VFNXDAbeIWDWiFCNM5qncUBDWaEV7NfE7oZbDt2mgfW4MvbKdbYiGOLoM32gbTv608UMd0XktEYSD7w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.0.tgz",
+      "integrity": "sha512-ezjfSQMP7ArdUsbBwbQIfwAlhE84I2iVnzQNCFSveqV42q+BmKlzVpf7mxv5EchLcoWU4y6/heFzVg1F+hodUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.0.tgz",
+      "integrity": "sha512-9+qTWGW9AZRhnUgwtTwzNwcPlL87ngkeN0LA+q1bADvmY9aNvWaF2TFW8BZgnQPYxpDI7+rMVLivcd4V737TAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.0.tgz",
+      "integrity": "sha512-T1dMEQhXA/jkJ/jyMIw9IovK8bSUq7A8kLIlvZTb/6YIVsp2zLavr4F3oyllHWo7eIVJRyE5n3tUjQJEbE1IuQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.0.tgz",
+      "integrity": "sha512-2as0LgT7qQpyceQq6VUJYnumUMUrgGQCWIiDIN9DE0/tglsk6o66uCB4f3djRawAltvfCNLyZZrsqbPA6inCsA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.0.tgz",
+      "integrity": "sha512-bVURMg+6eNN9C/yc0aVjooZcwTTtYF4YW3xta5pP0//r3o1V8gXEHXWCndj47w/HhwsFroZrFhR+6uQP5T0n0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.0.tgz",
+      "integrity": "sha512-Ful8pM/2yYI83PViWdFdpZhdI8HJ5qsXANe5atypbHDf+KIBBDsZsbyy8hbXnULVvW9NsTh5DHwbcBftyLTfiw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.0.tgz",
+      "integrity": "sha512-9Gp/DgrkzfUBmNPVTyPTvay+4xEP7M/clXpj3efXBcm6uTIVIgDg4rqUpqKXvLEuFRVuEpSAOkhgNeecvaZ4Cg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.0.tgz",
+      "integrity": "sha512-m9tsJz54LUXkSYM8+8PG81B9IKK5r+2T0clMq4QrS16xFosufU7firBDAZEsDheDs7wTlP7h3++S7lMsU955HA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.0.tgz",
+      "integrity": "sha512-3UvJ5PNVU16aJf6M3tFI24pWzAl2/ynfbyRN3ICyQajK1lSkrnVYNnLz3v04J32qKa0FczJc22zeToc0lr2A3w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.0.tgz",
+      "integrity": "sha512-vRWUAbYLGHBZS6Q8Msb2sfnf1fvJf+47t8l/TwOerM2qArzy+IeNMTHrYLHXh95h8MoatPHI5hhSZNs+mGXKPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.0.tgz",
+      "integrity": "sha512-c00T5SYENHAt86cfW47URaP3Us5vLC/4QO7GYud1G5VNRffCwwCuBspwqYrriuJB+5m0WFzClCn9wed0FBjKvg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.0.tgz",
+      "integrity": "sha512-krrCDilhXOwFkSkO3Wm9I/f9H0L92XHHwy2fwxjukxIbh0dem8gZqOW5Y8BsHrpJv5qwlRBV+Wl4ZFyRWhUpwg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.0.tgz",
+      "integrity": "sha512-7pfYFSTc4/rUC/FtAI0Qp6QthDBCIi6/AuP1xYqFk5vanI6KnL5dWKP60OM/05LOsbwTmIcvr6eXC4CJuJ75IA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.0.tgz",
+      "integrity": "sha512-7SDIalKeIpG0Ifogbbdn58HmSotYMlf23K3dCJEmiVd9Fg36Vmni82iPQec27N3wY4Bvbxftkxz6vSx9OcouTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.0.tgz",
+      "integrity": "sha512-eRZevouTH2i1HeAVLqJuLnt256krQkGY0TN6WsTmsIhuzbh457HuWDMakKwmi0Cjadux983CoSr8Lim2QhUIFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.0.tgz",
+      "integrity": "sha512-3oVS7FLGa4U1qcvao9ylGxrjXZyUQqR8UwxEcnUEyPX53O/C/mKDZegNXTdHCP+h3e6ta/f1EN38Yif1mmZHYg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.0.tgz",
+      "integrity": "sha512-yTB9TgfWj5wHe5QgktAgXTLLot1gvEjl1NiPPAUiCs4oPrIWFl5V4nC3GrkNdj9LaAU4s94nVrGbGOCqUpyWsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.0.tgz",
+      "integrity": "sha512-5LOhoaesY3doG1c+ac/2JtgREpKoJr5bUHH8tKY0V8di7+uSV6BwLs2PlR0/yzefGOkR+wE7ZolZphHCsyG5Rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.0.tgz",
+      "integrity": "sha512-yYkWHhmbhRTWTnWos5HC4GcPQfjlzzCNbM9e/+GXrLuaBXYA3qSDR9f0Vgufd5S8yX81U8jPKp7ZnAjZFMtRnw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.0.tgz",
+      "integrity": "sha512-SoTb6lPg25xZlA2ibwQ++ahCCnH+FP0qmEuafMJ4gznZKOlXioKEAeJLgCrqjM98ACziXM9V1amFjICVL4IFoA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.0.tgz",
+      "integrity": "sha512-5L+T1fMX4RIEBoZzT0+sQ0PhTS36NULFmMXtl1TZo44TMAROIMHbZufSOjVWt/Y622BtxgxtaNOokbTDvfsrZA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/autoprefixer": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
+      "integrity": "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.2",
+        "caniuse-lite": "^1.0.30001787",
+        "fraction.js": "^5.3.4",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.38",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
+      "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
+    },
+    "node_modules/didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.375",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.375.tgz",
+      "integrity": "sha512-ZWP5eB4BVPW/ZYo9252hQZHZ5XavtsTgpbhcmMmRwymavC5AsLWQWBPaKMeNd2LW0KGby5HPXvj7+sr4ta5j/Q==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
+      "integrity": "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.47",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
+      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
+      "integrity": "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
+      "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
+      "deprecated": "1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "license": "MIT",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.0.tgz",
+      "integrity": "sha512-nc72Wgq62I7rtDV4izT5/aaS0zxy3kttkinf9586ApknY3jZO9NYsmtc24fUckA0X7Q2v+ML4a15pdUlV5V/jA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.0",
+        "@rollup/rollup-android-arm64": "4.62.0",
+        "@rollup/rollup-darwin-arm64": "4.62.0",
+        "@rollup/rollup-darwin-x64": "4.62.0",
+        "@rollup/rollup-freebsd-arm64": "4.62.0",
+        "@rollup/rollup-freebsd-x64": "4.62.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.0",
+        "@rollup/rollup-linux-arm64-musl": "4.62.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.0",
+        "@rollup/rollup-linux-loong64-musl": "4.62.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.0",
+        "@rollup/rollup-linux-x64-gnu": "4.62.0",
+        "@rollup/rollup-linux-x64-musl": "4.62.0",
+        "@rollup/rollup-openbsd-x64": "4.62.0",
+        "@rollup/rollup-openharmony-arm64": "4.62.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.0",
+        "@rollup/rollup-win32-x64-gnu": "4.62.0",
+        "@rollup/rollup-win32-x64-msvc": "4.62.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "3.4.19",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
+      "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.7",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/python/danfault/spoti-ui/package.json
+++ b/python/danfault/spoti-ui/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "spoti-ui",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "recharts": "^2.12.7"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.3.1",
+    "autoprefixer": "^10.4.19",
+    "postcss": "^8.4.38",
+    "tailwindcss": "^3.4.4",
+    "vite": "^5.3.1"
+  }
+}

--- a/python/danfault/spoti-ui/postcss.config.js
+++ b/python/danfault/spoti-ui/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/python/danfault/spoti-ui/src/Analysis.jsx
+++ b/python/danfault/spoti-ui/src/Analysis.jsx
@@ -1,0 +1,117 @@
+import { useEffect, useState } from 'react'
+import ArtistChart from './ArtistChart'
+import BpmHistogram from './BpmHistogram'
+import BpmTimeline from './BpmTimeline'
+
+export default function Analysis({ file }) {
+  const [state, setState] = useState({ status: 'idle', playlist: null, features: null })
+
+  useEffect(() => {
+    if (!file) return
+    setState({ status: 'loading', playlist: null, features: null })
+    Promise.all([
+      fetch(`/api/playlist?file=${encodeURIComponent(file)}`).then(r => r.json()),
+      fetch(`/api/audio-features?file=${encodeURIComponent(file)}`).then(r => r.json()),
+    ]).then(([playlist, features]) => {
+      setState({ status: 'ready', playlist, features })
+    }).catch(() => {
+      setState({ status: 'error', playlist: null, features: null })
+    })
+  }, [file])
+
+  if (!file) {
+    return (
+      <div className="text-sp-muted text-sm text-center py-20">
+        ← Pick a playlist in the Library tab.
+      </div>
+    )
+  }
+
+  if (state.status === 'loading') {
+    return (
+      <div className="text-sp-muted text-sm text-center py-20">
+        Fetching audio features…
+      </div>
+    )
+  }
+
+  if (state.status === 'error') {
+    return (
+      <div className="text-sp-muted text-sm text-center py-20">
+        Failed to load playlist data.
+      </div>
+    )
+  }
+
+  const { playlist, features } = state
+  const tracks = playlist?.tracks ?? []
+  const pl = playlist?.playlist ?? {}
+
+  // Resolve BPM for a track: enriched field → embedded Spotify features → live API features
+  const getBpm = t => {
+    if (t.bpm != null) return t.bpm
+    const f = t.features ?? features?.[t.id]
+    return f?.tempo ?? null
+  }
+
+  // Artist distribution
+  const ac = {}
+  tracks.forEach(t =>
+    (t.artists ?? []).forEach(a => { ac[a.name] = (ac[a.name] ?? 0) + 1 })
+  )
+  const artistData = Object.entries(ac)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 25)
+    .map(([name, count]) => ({ name, count }))
+
+  // BPM series (original playlist order, skipping tracks without data)
+  const bpmData = tracks.reduce((acc, t, i) => {
+    const bpm = getBpm(t)
+    if (bpm == null) return acc
+    acc.push({
+      position: i + 1,
+      bpm: Math.round(bpm * 10) / 10,
+      name: t.name,
+      artist: (t.artists ?? []).map(a => a.name).join(', '),
+      source: t.bpm_source ?? 'spotify',
+    })
+    return acc
+  }, [])
+
+  return (
+    <div>
+      <div className="mb-7">
+        <h2 className="text-lg font-semibold text-sp-text">{pl.name}</h2>
+        <p className="text-sm text-sp-muted mt-1">{pl.total} tracks · {pl.owner}</p>
+      </div>
+
+      <div className="flex flex-col gap-5">
+        <ChartCard title="Artist Distribution" badge="top 25">
+          <ArtistChart data={artistData} />
+        </ChartCard>
+
+        <ChartCard title="BPM Distribution">
+          <BpmHistogram bpmValues={bpmData.map(d => d.bpm)} />
+        </ChartCard>
+
+        <ChartCard title="BPM Over Playlist">
+          <BpmTimeline data={bpmData} />
+        </ChartCard>
+      </div>
+    </div>
+  )
+}
+
+function ChartCard({ title, badge, children }) {
+  return (
+    <div className="bg-sp-surface rounded-xl p-6">
+      <div className="flex items-baseline gap-2 mb-5">
+        <h3 className="text-xs font-bold uppercase tracking-widest text-sp-muted">{title}</h3>
+        {badge && (
+          <span className="text-xs text-sp-green font-medium">{badge}</span>
+        )}
+      </div>
+      {children}
+    </div>
+  )
+}

--- a/python/danfault/spoti-ui/src/App.jsx
+++ b/python/danfault/spoti-ui/src/App.jsx
@@ -1,0 +1,53 @@
+import { useState } from 'react'
+import Library from './Library'
+import Analysis from './Analysis'
+
+const TABS = ['library', 'analysis']
+
+export default function App() {
+  const [tab, setTab] = useState('library')
+  const [selectedFile, setSelectedFile] = useState(null)
+
+  function handleAnalyse(file) {
+    setSelectedFile(file)
+    setTab('analysis')
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col bg-sp-black text-sp-text font-sans">
+      {/* Header */}
+      <header className="bg-black border-b border-sp-border px-7 py-4 flex items-center gap-3 flex-shrink-0">
+        <span className="text-sp-green font-bold text-base tracking-tight select-none">⬤ Spoti</span>
+        <span className="text-sp-muted text-xs">Dashboard</span>
+      </header>
+
+      {/* Tab bar */}
+      <nav className="bg-sp-surface border-b border-sp-border px-6 flex flex-shrink-0">
+        {TABS.map(t => (
+          <button
+            key={t}
+            onClick={() => setTab(t)}
+            className={[
+              'px-5 py-3 text-sm capitalize border-b-2 transition-colors duration-150 outline-none',
+              tab === t
+                ? 'text-sp-text border-sp-green'
+                : 'text-sp-muted border-transparent hover:text-sp-sub',
+            ].join(' ')}
+          >
+            {t}
+          </button>
+        ))}
+      </nav>
+
+      {/* Content */}
+      <main className="flex-1 w-full max-w-5xl mx-auto px-7 py-7">
+        {tab === 'library' && (
+          <Library onAnalyse={handleAnalyse} selectedFile={selectedFile} />
+        )}
+        {tab === 'analysis' && (
+          <Analysis file={selectedFile} />
+        )}
+      </main>
+    </div>
+  )
+}

--- a/python/danfault/spoti-ui/src/ArtistChart.jsx
+++ b/python/danfault/spoti-ui/src/ArtistChart.jsx
@@ -1,0 +1,64 @@
+import {
+  BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer,
+} from 'recharts'
+
+const GREEN = '#1db954'
+const MUTED = '#666'
+const LABEL = '#b3b3b3'
+
+const tooltipStyle = {
+  background: '#1a1a1a',
+  border: '1px solid #333',
+  borderRadius: 8,
+  fontSize: 13,
+  color: '#e4e4e4',
+}
+
+export default function ArtistChart({ data }) {
+  if (!data.length) {
+    return <Empty>No artist data.</Empty>
+  }
+
+  // Highest count at top → reverse for vertical bar chart
+  const reversed = [...data].reverse()
+  const height = Math.max(280, reversed.length * 26 + 40)
+
+  return (
+    <ResponsiveContainer width="100%" height={height}>
+      <BarChart
+        layout="vertical"
+        data={reversed}
+        margin={{ top: 0, right: 16, bottom: 0, left: 0 }}
+      >
+        <XAxis
+          type="number"
+          tick={{ fill: MUTED, fontSize: 11 }}
+          axisLine={false}
+          tickLine={false}
+          allowDecimals={false}
+        />
+        <YAxis
+          type="category"
+          dataKey="name"
+          width={155}
+          tick={{ fill: LABEL, fontSize: 12 }}
+          axisLine={false}
+          tickLine={false}
+        />
+        <Tooltip
+          cursor={{ fill: '#222' }}
+          contentStyle={tooltipStyle}
+          labelStyle={{ color: '#e4e4e4', fontWeight: 600 }}
+          formatter={v => [v, 'tracks']}
+        />
+        <Bar dataKey="count" fill={GREEN} radius={[0, 4, 4, 0]} maxBarSize={18} />
+      </BarChart>
+    </ResponsiveContainer>
+  )
+}
+
+function Empty({ children }) {
+  return (
+    <div className="text-sp-muted text-sm text-center py-10">{children}</div>
+  )
+}

--- a/python/danfault/spoti-ui/src/BpmHistogram.jsx
+++ b/python/danfault/spoti-ui/src/BpmHistogram.jsx
@@ -1,0 +1,67 @@
+import {
+  BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer,
+} from 'recharts'
+
+const GREEN = '#1db954'
+const MUTED = '#666'
+
+const tooltipStyle = {
+  background: '#1a1a1a',
+  border: '1px solid #333',
+  borderRadius: 8,
+  fontSize: 13,
+  color: '#e4e4e4',
+}
+
+function buildBins(values, numBins = 20) {
+  if (!values.length) return []
+  const min = Math.floor(Math.min(...values))
+  const max = Math.ceil(Math.max(...values))
+  const step = Math.max(1, Math.ceil((max - min) / numBins))
+  const bins = []
+  for (let lo = min; lo < max; lo += step) {
+    const hi = lo + step
+    const count = values.filter(v => v >= lo && v < hi).length
+    if (count > 0) bins.push({ label: `${lo}–${hi}`, lo, count })
+  }
+  return bins
+}
+
+export default function BpmHistogram({ bpmValues }) {
+  const bins = buildBins(bpmValues)
+
+  if (!bins.length) {
+    return (
+      <div className="text-sp-muted text-sm text-center py-10">
+        No BPM data — audio features unavailable for this playlist.
+      </div>
+    )
+  }
+
+  return (
+    <ResponsiveContainer width="100%" height={260}>
+      <BarChart data={bins} margin={{ top: 0, right: 16, bottom: 0, left: 0 }}>
+        <XAxis
+          dataKey="label"
+          tick={{ fill: MUTED, fontSize: 11 }}
+          axisLine={false}
+          tickLine={false}
+          interval="preserveStartEnd"
+        />
+        <YAxis
+          tick={{ fill: MUTED, fontSize: 11 }}
+          axisLine={false}
+          tickLine={false}
+          allowDecimals={false}
+        />
+        <Tooltip
+          cursor={{ fill: '#222' }}
+          contentStyle={tooltipStyle}
+          labelStyle={{ color: '#e4e4e4', fontWeight: 600 }}
+          formatter={v => [v, 'tracks']}
+        />
+        <Bar dataKey="count" fill={GREEN} radius={[4, 4, 0, 0]} />
+      </BarChart>
+    </ResponsiveContainer>
+  )
+}

--- a/python/danfault/spoti-ui/src/BpmTimeline.jsx
+++ b/python/danfault/spoti-ui/src/BpmTimeline.jsx
@@ -1,0 +1,71 @@
+import {
+  LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid,
+  ResponsiveContainer, ReferenceLine,
+} from 'recharts'
+
+const GREEN = '#1db954'
+const MUTED = '#666'
+const GRID = '#222'
+
+function CustomTooltip({ active, payload }) {
+  if (!active || !payload?.length) return null
+  const d = payload[0].payload
+  return (
+    <div className="bg-sp-surface border border-sp-border rounded-lg px-3 py-2 text-sm shadow-xl">
+      <p className="font-semibold text-sp-text leading-tight">{d.name}</p>
+      <p className="text-sp-muted text-xs mt-0.5">{d.artist}</p>
+      <p className="text-sp-green font-bold mt-1.5">{d.bpm} BPM</p>
+      <p className="text-sp-muted text-xs">#{d.position}</p>
+    </div>
+  )
+}
+
+export default function BpmTimeline({ data }) {
+  if (!data.length) {
+    return (
+      <div className="text-sp-muted text-sm text-center py-10">
+        No BPM data — audio features unavailable for this playlist.
+      </div>
+    )
+  }
+
+  const bpms = data.map(d => d.bpm)
+  const avg = Math.round(bpms.reduce((s, v) => s + v, 0) / bpms.length)
+
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <LineChart data={data} margin={{ top: 4, right: 16, bottom: 0, left: 0 }}>
+        <CartesianGrid stroke={GRID} strokeDasharray="0" vertical={false} />
+        <XAxis
+          dataKey="position"
+          tick={{ fill: MUTED, fontSize: 11 }}
+          axisLine={false}
+          tickLine={false}
+          label={{ value: 'Track #', position: 'insideBottomRight', offset: -4, fill: MUTED, fontSize: 11 }}
+        />
+        <YAxis
+          tick={{ fill: MUTED, fontSize: 11 }}
+          axisLine={false}
+          tickLine={false}
+          domain={['auto', 'auto']}
+          label={{ value: 'BPM', angle: -90, position: 'insideLeft', offset: 12, fill: MUTED, fontSize: 11 }}
+        />
+        <ReferenceLine
+          y={avg}
+          stroke="#444"
+          strokeDasharray="4 4"
+          label={{ value: `avg ${avg}`, position: 'right', fill: MUTED, fontSize: 11 }}
+        />
+        <Tooltip content={<CustomTooltip />} />
+        <Line
+          type="monotone"
+          dataKey="bpm"
+          stroke={GREEN}
+          strokeWidth={1.5}
+          dot={{ r: 3, fill: GREEN, strokeWidth: 0 }}
+          activeDot={{ r: 5, fill: GREEN, strokeWidth: 0 }}
+        />
+      </LineChart>
+    </ResponsiveContainer>
+  )
+}

--- a/python/danfault/spoti-ui/src/Library.jsx
+++ b/python/danfault/spoti-ui/src/Library.jsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from 'react'
+
+export default function Library({ onAnalyse, selectedFile }) {
+  const [playlists, setPlaylists] = useState(null)
+
+  useEffect(() => {
+    fetch('/api/playlists')
+      .then(r => r.json())
+      .then(setPlaylists)
+      .catch(() => setPlaylists([]))
+  }, [])
+
+  if (playlists === null) {
+    return <Placeholder>Loading…</Placeholder>
+  }
+
+  if (!playlists.length) {
+    return (
+      <Placeholder>
+        <p>No exported playlists found.</p>
+        <p className="mt-3">
+          <code className="bg-sp-surface2 text-sp-sub px-2 py-1 rounded text-xs">
+            spoti playlist-export "my playlist"
+          </code>
+        </p>
+      </Placeholder>
+    )
+  }
+
+  return (
+    <div className="grid gap-4" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))' }}>
+      {playlists.map(p => (
+        <PlaylistCard
+          key={p.file}
+          playlist={p}
+          selected={selectedFile === p.file}
+          onAnalyse={() => onAnalyse(p.file)}
+        />
+      ))}
+    </div>
+  )
+}
+
+function PlaylistCard({ playlist, selected, onAnalyse }) {
+  return (
+    <div
+      className={[
+        'bg-sp-surface rounded-xl p-5 flex flex-col border-2 transition-all duration-150',
+        selected ? 'border-sp-green' : 'border-transparent hover:bg-sp-surface2',
+      ].join(' ')}
+    >
+      <div
+        className="font-semibold text-sm truncate mb-1 text-sp-text"
+        title={playlist.name}
+      >
+        {playlist.name}
+      </div>
+      <div className="text-xs text-sp-muted flex-1 mb-4">
+        {playlist.total} tracks · {playlist.owner}
+      </div>
+      <button
+        onClick={onAnalyse}
+        className="w-full bg-sp-green text-black text-xs font-bold rounded-full py-2 hover:bg-sp-greenhov transition-colors duration-150"
+      >
+        Analyse →
+      </button>
+    </div>
+  )
+}
+
+function Placeholder({ children }) {
+  return (
+    <div className="text-sp-muted text-sm text-center py-20 leading-relaxed">
+      {children}
+    </div>
+  )
+}

--- a/python/danfault/spoti-ui/src/index.css
+++ b/python/danfault/spoti-ui/src/index.css
@@ -1,0 +1,19 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: #0d0d0d;
+  color: #e4e4e4;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* Recharts tooltip dark override */
+.recharts-tooltip-wrapper .recharts-default-tooltip {
+  background: #1a1a1a !important;
+  border: 1px solid #333 !important;
+  border-radius: 8px !important;
+}

--- a/python/danfault/spoti-ui/src/main.jsx
+++ b/python/danfault/spoti-ui/src/main.jsx
@@ -1,0 +1,10 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import './index.css'
+import App from './App.jsx'
+
+createRoot(document.getElementById('root')).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+)

--- a/python/danfault/spoti-ui/tailwind.config.js
+++ b/python/danfault/spoti-ui/tailwind.config.js
@@ -1,0 +1,27 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ['./index.html', './src/**/*.{js,jsx}'],
+  theme: {
+    extend: {
+      colors: {
+        sp: {
+          black:    '#0d0d0d',
+          dark:     '#121212',
+          surface:  '#1a1a1a',
+          surface2: '#252525',
+          surface3: '#2e2e2e',
+          green:    '#1db954',
+          greenhov: '#1ed760',
+          text:     '#e4e4e4',
+          sub:      '#b3b3b3',
+          muted:    '#666666',
+          border:   '#2a2a2a',
+        },
+      },
+      fontFamily: {
+        sans: ['-apple-system', 'BlinkMacSystemFont', '"Segoe UI"', 'Roboto', 'sans-serif'],
+      },
+    },
+  },
+  plugins: [],
+}

--- a/python/danfault/spoti-ui/vite.config.js
+++ b/python/danfault/spoti-ui/vite.config.js
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://127.0.0.1:8889',
+        changeOrigin: true,
+      },
+    },
+  },
+})


### PR DESCRIPTION
## Summary
Adds three tools to the `danfault` Python package — an **Arc browser sidebar exporter**, a **Spotify Web API CLI**, and a **`vault` config resolver** — plus a small React dashboard for the Spotify data. All are wired into the main Typer app.

## What changed

### `arc` — Arc sidebar → Markdown (`arc.py`) - Mac only

Reads Arc's undocumented `StorableSidebar.json` from disk (never modifies it; parses a temp copy) and rebuilds the space/folder/tab tree.

```
danfault arc tabs list
danfault arc tabs backup ["Folder Name"] [--space ..] [--out ..] [--clipboard] [--headings]
```

Parsing layer is pure stdlib; only the CLI uses Typer. Ships with a design note (`arc-folder-to-markdown-plan.md`).

### `spotify` — control Spotify from the terminal (`spotify.py`)

Drives **any** device (laptop/phone/speakers) via the Spotify Web API.

- Auth: OAuth 2.0 **Authorization Code + PKCE** — no client secret; `spoti login` opens the browser and a local server catches the redirect. Tokens cached at `~/.config/danfault/spotify.json` (`chmod 600`) and refreshed silently.
- Commands: `login`/`logout`, `now`, `play`/`pause`/`playpause`/`next`/`prev`, `vol`, `shuffle`, `repeat`, `devices`/`transfer`, `search`, `playlist-export`, `enrich-bpm`, and `ui`.
- Installed as the standalone **`spoti`** command _and_ as `danfault spotify`.

### `spoti-ui/` — Vite + React + Tailwind dashboard

Visualizes an exported playlist (artist chart, BPM histogram/timeline, library view). `spoti ui` serves it. Source only — `node_modules/` and `dist/` are gitignored.

> NOTE: this will probably will be removed later. Spotify don't allow gathering BPM on it's API nowadays.

### `vault` — resolve locations from machine-local config (`vault.py`, +~130)

Reads `~/.config/danfault/vault.yaml` (never committed) so tools and skills reference logical names instead of hardcoding personal paths:

```
danfault vault path [--vault NAME]      # absolute path to a vault
danfault vault domains [--vault NAME]   # a vault's declared note domains
danfault vault repos [--github]         # every configured repo's path (or owner/repo)
danfault vault repo NAME [--github]     # one repo's path (or its slug)
```

The `.claude` skills (branch `chore/repo-meta`) call these instead of embedding paths, which is what keeps company/personal references out of the committed tree.

### Wiring & docs

- `main.py` — registers the `arc`, `spotify`, and `vault` sub-apps.
- `pyproject.toml` — deps `requests`, `questionary`, `pyyaml`; new `spoti` entry point.
- `docs/spoti.md` — full usage guide.
- `examples/spotify/corremo.json` — sample `playlist-export` output (+ README).

## Notes for reviewer

- No secrets in code — PKCE means only a public Client ID is needed; `vault.py` reads paths from local config, none are hardcoded.
- `main.py` imports `arc`, `spotify`, and `vault`, so they intentionally ship together.
- `examples/spotify/corremo.json` is committed **sample** data, not something the tools read at runtime.

## Testing

```bash
cd python/danfault && pip install -e .
danfault arc tabs list
danfault vault path        # needs ~/.config/danfault/vault.yaml
spoti login && spoti now
cd spoti-ui && npm install && npm run dev
```
