### PR TITLE
feat: add terminal config backup/restore scripts

### DIFF
--- a/terminal-configs/README.md
+++ b/terminal-configs/README.md
@@ -1,0 +1,38 @@
+# terminal-configs
+
+Version-controlled backups of terminal settings (themes, profiles, colors,
+keybindings, fonts).
+
+- **iTerm2** (macOS) — stored as `com.googlecode.iterm2.plist`
+- **GNOME Terminal** (Linux) — stored as `gnome-terminal.dconf`
+
+Each script auto-detects what's available on the current machine and skips the
+other terminal, so the same folder works on both macOS and Linux.
+
+## Usage
+
+```bash
+cd terminal-configs
+
+# Save current settings into this folder, then commit them
+./backup.sh
+git add . && git commit -m "backup terminal configs"
+
+# Restore settings on a new/clean machine after cloning
+./restore.sh
+```
+
+## Notes
+
+- **`backup.sh`** flushes iTerm2's in-memory prefs (`killall cfprefsd`) before
+  exporting so the saved plist isn't stale.
+- **Quit iTerm2 before running `restore.sh`** — otherwise iTerm overwrites the
+  freshly imported prefs when it exits.
+- After restoring: restart iTerm2 (or log out/in) and open a new GNOME Terminal
+  window to see the changes.
+
+## Just the iTerm2 color scheme
+
+To export only the palette (not full prefs):
+`Settings → Profiles → Colors → Color Presets → Export…` → produces a
+`.itermcolors` file you can drop in here too.

--- a/terminal-configs/backup.sh
+++ b/terminal-configs/backup.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# Backs up terminal configs into this folder so they can be version-controlled.
+#   - iTerm2 (macOS): exports com.googlecode.iterm2.plist
+#   - GNOME Terminal (Linux): dumps /org/gnome/terminal/ from dconf
+# Whichever isn't available on this machine is skipped.
+
+set -euo pipefail
+
+DEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# --- iTerm2 ---------------------------------------------------------------
+if command -v defaults >/dev/null 2>&1 && \
+   defaults read com.googlecode.iterm2 >/dev/null 2>&1; then
+  echo "==> Backing up iTerm2 prefs"
+  # iTerm caches prefs in memory; flush them so the export isn't stale.
+  killall cfprefsd >/dev/null 2>&1 || true
+  defaults export com.googlecode.iterm2 "$DEST/com.googlecode.iterm2.plist"
+  echo "    -> $DEST/com.googlecode.iterm2.plist"
+else
+  echo "==> iTerm2 not found, skipping"
+fi
+
+# --- GNOME Terminal -------------------------------------------------------
+if command -v dconf >/dev/null 2>&1 && \
+   dconf list /org/gnome/terminal/ >/dev/null 2>&1; then
+  echo "==> Backing up GNOME Terminal settings"
+  dconf dump /org/gnome/terminal/ > "$DEST/gnome-terminal.dconf"
+  echo "    -> $DEST/gnome-terminal.dconf"
+else
+  echo "==> GNOME Terminal not found, skipping"
+fi
+
+echo "Done. Commit the changes in $DEST to save them."

--- a/terminal-configs/restore.sh
+++ b/terminal-configs/restore.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# Restores terminal configs from this folder.
+#   - iTerm2 (macOS): imports com.googlecode.iterm2.plist
+#   - GNOME Terminal (Linux): loads gnome-terminal.dconf into dconf
+# Quit iTerm2 before running so it doesn't overwrite the import on exit.
+
+set -euo pipefail
+
+SRC="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# --- iTerm2 ---------------------------------------------------------------
+ITERM_PLIST="$SRC/com.googlecode.iterm2.plist"
+if command -v defaults >/dev/null 2>&1 && [ -f "$ITERM_PLIST" ]; then
+  echo "==> Restoring iTerm2 prefs"
+  defaults import com.googlecode.iterm2 "$ITERM_PLIST"
+  killall cfprefsd >/dev/null 2>&1 || true
+  echo "    Imported. Restart iTerm2 (or log out/in) to see changes."
+else
+  echo "==> No iTerm2 backup to restore, skipping"
+fi
+
+# --- GNOME Terminal -------------------------------------------------------
+GNOME_DCONF="$SRC/gnome-terminal.dconf"
+if command -v dconf >/dev/null 2>&1 && [ -f "$GNOME_DCONF" ]; then
+  echo "==> Restoring GNOME Terminal settings"
+  dconf load /org/gnome/terminal/ < "$GNOME_DCONF"
+  echo "    Loaded. Open a new GNOME Terminal window to see changes."
+else
+  echo "==> No GNOME Terminal backup to restore, skipping"
+fi
+
+echo "Done."


### PR DESCRIPTION
## Summary

Version-controllable backup/restore of terminal emulator settings, cross-platform (macOS iTerm2 + Linux GNOME Terminal), so terminal config travels with the repo.

## What changed

- **`backup.sh`** — exports whichever emulator is present, skips the other:
  - iTerm2 → `defaults export com.googlecode.iterm2` (flushes `cfprefsd` first so the export isn't stale).
  - GNOME Terminal → `dconf dump /org/gnome/terminal/`.
- **`restore.sh`** — imports those files back onto a new machine.
- **`README.md`** — usage and what each file is.

Both scripts are `set -euo pipefail` and resolve their own directory, so they can be run from anywhere.

## Notes for reviewer

- No secrets/PII (verified) — just terminal preferences.
- The exported artifacts (`*.plist`, `*.dconf`) are produced by running the scripts; this PR adds only the scripts + README.

## Testing

```bash
./terminal-configs/backup.sh    # writes plist/dconf into the folder
./terminal-configs/restore.sh   # re-imports them
```
